### PR TITLE
docs: expand CV documentation

### DIFF
--- a/SPONGE/constrain/constrain.cpp
+++ b/SPONGE/constrain/constrain.cpp
@@ -1,5 +1,9 @@
 ﻿#include "constrain.h"
 
+#include <set>
+
+#include "../xponge/xponge.h"
+
 void CONSTRAIN::Initial_Constrain(CONTROLLER* controller,
                                   const int atom_numbers, const float dt,
                                   const VECTOR box_length, float* atom_mass,
@@ -96,13 +100,17 @@ void CONSTRAIN::Initial_List(CONTROLLER* controller, PAIR_DISTANCE con_dis,
                                 "CONSTRAIN::Add_HBond_To_Constrain_Pair");
         constrain_mass = atof(controller->Command(this->module_name, "mass"));
     }
+    const auto& explicit_constraints =
+        Xponge::system.classical_force_field.constraints;
     // 预先分配一个足够大的CONSTRAIN_PAIR用于临时存储
     Malloc_Safely((void**)&h_bond_pair,
-                  sizeof(CONSTRAIN_PAIR) * con_dis.size());
+                  sizeof(CONSTRAIN_PAIR) *
+                      (con_dis.size() + explicit_constraints.r0.size()));
     int s = 0;
     float mass_a, mass_b;
     int atom_a, atom_b;
     float r0;
+    std::set<std::pair<int, int>> added_pairs;
     for (auto& i : con_dis)
     {
         atom_a = i.first.first;
@@ -117,8 +125,30 @@ void CONSTRAIN::Initial_List(CONTROLLER* controller, PAIR_DISTANCE con_dis,
             h_bond_pair[s].atom_j_serial = atom_b;
             h_bond_pair[s].constant_r = r0;
             h_bond_pair[s].constrain_k = mass_a * mass_b / (mass_a + mass_b);
+            added_pairs.insert({atom_a, atom_b});
             s = s + 1;
         }
+    }
+    for (std::size_t i = 0; i < explicit_constraints.r0.size(); i++)
+    {
+        atom_a = explicit_constraints.atom_a[i];
+        atom_b = explicit_constraints.atom_b[i];
+        if (atom_b < atom_a)
+        {
+            std::swap(atom_a, atom_b);
+        }
+        if (added_pairs.count({atom_a, atom_b}) > 0)
+        {
+            continue;
+        }
+        mass_a = atom_mass[atom_a];
+        mass_b = atom_mass[atom_b];
+        h_bond_pair[s].atom_i_serial = atom_a;
+        h_bond_pair[s].atom_j_serial = atom_b;
+        h_bond_pair[s].constant_r = explicit_constraints.r0[i];
+        h_bond_pair[s].constrain_k = mass_a * mass_b / (mass_a + mass_b);
+        added_pairs.insert({atom_a, atom_b});
+        s = s + 1;
     }
     bond_constrain_pair_numbers = s;
     if (controller->Command_Exist(this->module_name, "angle") &&

--- a/SPONGE/xponge/ir/forcefield.h
+++ b/SPONGE/xponge/ir/forcefield.h
@@ -13,6 +13,13 @@ struct Bonds
     std::vector<float> r0;
 };
 
+struct DistanceConstraints
+{
+    std::vector<int> atom_a;
+    std::vector<int> atom_b;
+    std::vector<float> r0;
+};
+
 struct Angles
 {
     std::vector<int> atom_a;
@@ -115,6 +122,7 @@ struct VirtualAtoms
 struct ClassicalForceField
 {
     Bonds bonds;
+    DistanceConstraints constraints;
     Angles angles;
     Torsions dihedrals;
     Torsions impropers;

--- a/SPONGE/xponge/load/common.hpp
+++ b/SPONGE/xponge/load/common.hpp
@@ -43,6 +43,7 @@ static int Load_Ensure_Atom_Numbers(System* system, int atom_numbers,
 static void Load_Reset_Classical_Force_Field(ClassicalForceField* ff)
 {
     ff->bonds = Bonds{};
+    ff->constraints = DistanceConstraints{};
     ff->angles = Angles{};
     ff->dihedrals = Torsions{};
     ff->impropers = Torsions{};

--- a/SPONGE/xponge/load/gromacs.hpp
+++ b/SPONGE/xponge/load/gromacs.hpp
@@ -127,6 +127,32 @@ struct Gromacs_Dihedral
     std::vector<float> parameters;
 };
 
+struct Gromacs_Settle
+{
+    int ow = 0;
+    int funct = 0;
+    float doh = 0.0f;
+    float dhh = 0.0f;
+};
+
+struct Gromacs_Constraint
+{
+    int ai = 0;
+    int aj = 0;
+    int funct = 0;
+    std::vector<float> parameters;
+};
+
+struct Gromacs_CMap
+{
+    int ai = 0;
+    int aj = 0;
+    int ak = 0;
+    int al = 0;
+    int am = 0;
+    int funct = 0;
+};
+
 struct Gromacs_Molecule
 {
     std::string name;
@@ -136,6 +162,9 @@ struct Gromacs_Molecule
     std::vector<Gromacs_Pair> pairs;
     std::vector<Gromacs_Angle> angles;
     std::vector<Gromacs_Dihedral> dihedrals;
+    std::vector<Gromacs_Settle> settles;
+    std::vector<Gromacs_Constraint> constraints;
+    std::vector<Gromacs_CMap> cmaps;
 };
 
 struct Gromacs_Residue_Info
@@ -580,6 +609,40 @@ static const Gromacs_Pair_Type* Gromacs_Find_Pair_Type(
     return NULL;
 }
 
+static int Gromacs_Find_CMap_Type(
+    const std::vector<Gromacs_CMap_Type>& cmap_types, const std::string& ai,
+    const std::string& aj, const std::string& ak, const std::string& al,
+    const std::string& am, int funct)
+{
+    int match = -1;
+    int best_wildcards = 1000;
+    for (std::size_t i = 0; i < cmap_types.size(); i++)
+    {
+        const Gromacs_CMap_Type& type = cmap_types[i];
+        if (type.funct != funct)
+        {
+            continue;
+        }
+        bool forward = Gromacs_Type_Match(type.ai, ai) &&
+                       Gromacs_Type_Match(type.aj, aj) &&
+                       Gromacs_Type_Match(type.ak, ak) &&
+                       Gromacs_Type_Match(type.al, al) &&
+                       Gromacs_Type_Match(type.am, am);
+        if (!forward)
+        {
+            continue;
+        }
+        int wildcards = Gromacs_Count_Wildcards(
+            {type.ai, type.aj, type.ak, type.al, type.am});
+        if (wildcards < best_wildcards)
+        {
+            best_wildcards = wildcards;
+            match = static_cast<int>(i);
+        }
+    }
+    return match;
+}
+
 static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
 {
     const char* error_by = "Xponge::Load_Gromacs_Inputs";
@@ -911,6 +974,59 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
             }
             current_molecule->dihedrals.push_back(dihedral);
         }
+        else if (current_section == "settles")
+        {
+            if (current_molecule == NULL || tokens.size() < 4)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tinvalid [ settles ] section in GROMACS "
+                    "topology\n");
+            }
+            Gromacs_Settle settle;
+            settle.ow = std::stoi(tokens[0]);
+            settle.funct = std::stoi(tokens[1]);
+            settle.doh = std::stof(tokens[2]);
+            settle.dhh = std::stof(tokens[3]);
+            current_molecule->settles.push_back(settle);
+        }
+        else if (current_section == "constraints")
+        {
+            if (current_molecule == NULL || tokens.size() < 3)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tinvalid [ constraints ] section in GROMACS "
+                    "topology\n");
+            }
+            Gromacs_Constraint constraint;
+            constraint.ai = std::stoi(tokens[0]);
+            constraint.aj = std::stoi(tokens[1]);
+            constraint.funct = std::stoi(tokens[2]);
+            for (std::size_t i = 3; i < tokens.size(); i++)
+            {
+                constraint.parameters.push_back(std::stof(tokens[i]));
+            }
+            current_molecule->constraints.push_back(constraint);
+        }
+        else if (current_section == "cmap")
+        {
+            if (current_molecule == NULL || tokens.size() < 6)
+            {
+                controller->Throw_SPONGE_Error(spongeErrorBadFileFormat,
+                                               error_by,
+                                               "Reason:\n\tinvalid [ cmap ] "
+                                               "section in GROMACS topology\n");
+            }
+            Gromacs_CMap cmap;
+            cmap.ai = std::stoi(tokens[0]);
+            cmap.aj = std::stoi(tokens[1]);
+            cmap.ak = std::stoi(tokens[2]);
+            cmap.al = std::stoi(tokens[3]);
+            cmap.am = std::stoi(tokens[4]);
+            cmap.funct = std::stoi(tokens[5]);
+            current_molecule->cmaps.push_back(cmap);
+        }
         else if (current_section == "molecules")
         {
             if (tokens.size() < 2)
@@ -922,13 +1038,6 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
             }
             topology.system_molecules.push_back(
                 {tokens[0], std::stoi(tokens[1])});
-        }
-        else if (current_section == "settles" ||
-                 current_section == "constraints" || current_section == "cmap")
-        {
-            controller->Throw_SPONGE_Error(spongeErrorBadFileFormat, error_by,
-                                           "Reason:\n\tthis GROMACS topology "
-                                           "feature is not supported yet\n");
         }
     }
 
@@ -1083,11 +1192,31 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
     int atom_numbers = static_cast<int>(system->atoms.mass.size());
     system->exclusions.excluded_atoms.assign(atom_numbers, {});
     Xponge::Bonds& bonds = system->classical_force_field.bonds;
+    Xponge::DistanceConstraints& constraints =
+        system->classical_force_field.constraints;
     Xponge::Angles& angles = system->classical_force_field.angles;
     Xponge::UreyBradley& urey = system->classical_force_field.urey_bradley;
     Xponge::Torsions& dihedrals = system->classical_force_field.dihedrals;
     Xponge::Torsions& impropers = system->classical_force_field.impropers;
     Xponge::NB14& nb14 = system->classical_force_field.nb14;
+    Xponge::CMap& cmap = system->classical_force_field.cmap;
+
+    cmap.unique_type_numbers = static_cast<int>(topology.cmap_types.size());
+    cmap.resolution.resize(cmap.unique_type_numbers);
+    cmap.type_offset.resize(cmap.unique_type_numbers);
+    cmap.unique_gridpoint_numbers = 0;
+    for (int i = 0; i < cmap.unique_type_numbers; i++)
+    {
+        const Gromacs_CMap_Type& cmap_type = topology.cmap_types[i];
+        cmap.resolution[i] = cmap_type.resolution;
+        cmap.type_offset[i] = 16 * cmap.unique_gridpoint_numbers;
+        cmap.unique_gridpoint_numbers +=
+            cmap_type.resolution * cmap_type.resolution;
+        for (float value : cmap_type.grid)
+        {
+            cmap.grid_value.push_back(Gromacs_To_Kcal(value));
+        }
+    }
 
     std::unordered_map<std::string, int> atom_type_id;
     std::vector<std::string> ordered_types;
@@ -1146,20 +1275,56 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
             const std::vector<int>& local_to_global =
                 molecule_local_to_global[molecule_index];
             std::vector<std::vector<int>> adjacency(molecule.atoms.size());
+
+            auto require_local_atom = [&](int local_index)
+            {
+                if (local_index < 0 ||
+                    local_index >= static_cast<int>(molecule.atoms.size()))
+                {
+                    controller->Throw_SPONGE_Error(
+                        spongeErrorBadFileFormat, error_by,
+                        "Reason:\n\tGROMACS molecule atom index is out of "
+                        "range\n");
+                }
+            };
+
+            auto append_bond =
+                [&](int ai_local, int aj_local, float k, float r0)
+            {
+                require_local_atom(ai_local);
+                require_local_atom(aj_local);
+                bonds.atom_a.push_back(local_to_global[ai_local]);
+                bonds.atom_b.push_back(local_to_global[aj_local]);
+                bonds.k.push_back(k);
+                bonds.r0.push_back(r0);
+                adjacency[ai_local].push_back(aj_local);
+                adjacency[aj_local].push_back(ai_local);
+            };
+
+            auto append_constraint =
+                [&](int ai_local, int aj_local, float r0)
+            {
+                require_local_atom(ai_local);
+                require_local_atom(aj_local);
+                constraints.atom_a.push_back(local_to_global[ai_local]);
+                constraints.atom_b.push_back(local_to_global[aj_local]);
+                constraints.r0.push_back(r0);
+            };
+
             for (const Gromacs_Bond& bond : molecule.bonds)
             {
                 int ai_local = bond.ai - 1;
                 int aj_local = bond.aj - 1;
+                require_local_atom(ai_local);
+                require_local_atom(aj_local);
                 const Gromacs_Molecule_Atom& atom_i = molecule.atoms[ai_local];
                 const Gromacs_Molecule_Atom& atom_j = molecule.atoms[aj_local];
                 const Gromacs_Bond_Type* type = NULL;
                 if (bond.parameters.size() >= 2)
                 {
-                    bonds.atom_a.push_back(local_to_global[ai_local]);
-                    bonds.atom_b.push_back(local_to_global[aj_local]);
-                    bonds.k.push_back(Gromacs_To_Kcal(bond.parameters[1]) /
-                                      200.0f);
-                    bonds.r0.push_back(Gromacs_To_Angstrom(bond.parameters[0]));
+                    append_bond(ai_local, aj_local,
+                                Gromacs_To_Kcal(bond.parameters[1]) / 200.0f,
+                                Gromacs_To_Angstrom(bond.parameters[0]));
                 }
                 else
                 {
@@ -1172,13 +1337,48 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                             spongeErrorBadFileFormat, error_by,
                             "Reason:\n\tfailed to find GROMACS bond type\n");
                     }
-                    bonds.atom_a.push_back(local_to_global[ai_local]);
-                    bonds.atom_b.push_back(local_to_global[aj_local]);
-                    bonds.k.push_back(Gromacs_To_Kcal(type->kb) / 200.0f);
-                    bonds.r0.push_back(Gromacs_To_Angstrom(type->b0));
+                    append_bond(ai_local, aj_local,
+                                Gromacs_To_Kcal(type->kb) / 200.0f,
+                                Gromacs_To_Angstrom(type->b0));
                 }
-                adjacency[ai_local].push_back(aj_local);
-                adjacency[aj_local].push_back(ai_local);
+            }
+
+            for (const Gromacs_Settle& settle : molecule.settles)
+            {
+                int oxygen_local = settle.ow - 1;
+                int hydrogen_1_local = oxygen_local + 1;
+                int hydrogen_2_local = oxygen_local + 2;
+                require_local_atom(oxygen_local);
+                require_local_atom(hydrogen_1_local);
+                require_local_atom(hydrogen_2_local);
+                append_bond(oxygen_local, hydrogen_1_local, 0.0f,
+                            Gromacs_To_Angstrom(settle.doh));
+                append_constraint(oxygen_local, hydrogen_1_local,
+                                  Gromacs_To_Angstrom(settle.doh));
+                append_bond(oxygen_local, hydrogen_2_local, 0.0f,
+                            Gromacs_To_Angstrom(settle.doh));
+                append_constraint(oxygen_local, hydrogen_2_local,
+                                  Gromacs_To_Angstrom(settle.doh));
+                append_bond(hydrogen_1_local, hydrogen_2_local, 0.0f,
+                            Gromacs_To_Angstrom(settle.dhh));
+                append_constraint(hydrogen_1_local, hydrogen_2_local,
+                                  Gromacs_To_Angstrom(settle.dhh));
+            }
+
+            for (const Gromacs_Constraint& constraint : molecule.constraints)
+            {
+                if (constraint.parameters.empty())
+                {
+                    controller->Throw_SPONGE_Error(
+                        spongeErrorBadFileFormat, error_by,
+                        "Reason:\n\tfailed to resolve GROMACS constraint "
+                        "distance\n");
+                }
+                append_bond(constraint.ai - 1, constraint.aj - 1, 0.0f,
+                            Gromacs_To_Angstrom(constraint.parameters[0]));
+                append_constraint(constraint.ai - 1, constraint.aj - 1,
+                                  Gromacs_To_Angstrom(
+                                      constraint.parameters[0]));
             }
 
             for (int i = 0; i < static_cast<int>(molecule.atoms.size()); i++)
@@ -1214,6 +1414,40 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                             .push_back(local_to_global[j]);
                     }
                 }
+            }
+
+            for (const Gromacs_CMap& cmap_item : molecule.cmaps)
+            {
+                int ai_local = cmap_item.ai - 1;
+                int aj_local = cmap_item.aj - 1;
+                int ak_local = cmap_item.ak - 1;
+                int al_local = cmap_item.al - 1;
+                int am_local = cmap_item.am - 1;
+                require_local_atom(ai_local);
+                require_local_atom(aj_local);
+                require_local_atom(ak_local);
+                require_local_atom(al_local);
+                require_local_atom(am_local);
+                const Gromacs_Molecule_Atom& atom_i = molecule.atoms[ai_local];
+                const Gromacs_Molecule_Atom& atom_j = molecule.atoms[aj_local];
+                const Gromacs_Molecule_Atom& atom_k = molecule.atoms[ak_local];
+                const Gromacs_Molecule_Atom& atom_l = molecule.atoms[al_local];
+                const Gromacs_Molecule_Atom& atom_m = molecule.atoms[am_local];
+                int cmap_type = Gromacs_Find_CMap_Type(
+                    topology.cmap_types, atom_i.type, atom_j.type, atom_k.type,
+                    atom_l.type, atom_m.type, cmap_item.funct);
+                if (cmap_type < 0)
+                {
+                    controller->Throw_SPONGE_Error(
+                        spongeErrorBadFileFormat, error_by,
+                        "Reason:\n\tfailed to find GROMACS CMAP type\n");
+                }
+                cmap.atom_a.push_back(local_to_global[ai_local]);
+                cmap.atom_b.push_back(local_to_global[aj_local]);
+                cmap.atom_c.push_back(local_to_global[ak_local]);
+                cmap.atom_d.push_back(local_to_global[al_local]);
+                cmap.atom_e.push_back(local_to_global[am_local]);
+                cmap.cmap_type.push_back(cmap_type);
             }
 
             for (const Gromacs_Angle& angle : molecule.angles)

--- a/SPONGE/xponge/load/gromacs.hpp
+++ b/SPONGE/xponge/load/gromacs.hpp
@@ -1301,8 +1301,7 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                 adjacency[aj_local].push_back(ai_local);
             };
 
-            auto append_constraint =
-                [&](int ai_local, int aj_local, float r0)
+            auto append_constraint = [&](int ai_local, int aj_local, float r0)
             {
                 require_local_atom(ai_local);
                 require_local_atom(aj_local);
@@ -1376,9 +1375,9 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                 }
                 append_bond(constraint.ai - 1, constraint.aj - 1, 0.0f,
                             Gromacs_To_Angstrom(constraint.parameters[0]));
-                append_constraint(constraint.ai - 1, constraint.aj - 1,
-                                  Gromacs_To_Angstrom(
-                                      constraint.parameters[0]));
+                append_constraint(
+                    constraint.ai - 1, constraint.aj - 1,
+                    Gromacs_To_Angstrom(constraint.parameters[0]));
             }
 
             for (int i = 0; i < static_cast<int>(molecule.atoms.size()); i++)

--- a/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_features.py
+++ b/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_features.py
@@ -1,7 +1,12 @@
+import json
 import os
 import subprocess
 import textwrap
 from pathlib import Path
+
+
+def _toml_string(value):
+    return json.dumps(os.fspath(value))
 
 
 def _gro_atom(resid, resname, atomname, atomnr, xyz):
@@ -103,9 +108,9 @@ def test_direct_gromacs_topgro_accepts_settles_constraints_and_cmap(tmp_path):
             dt = 0
             cutoff = 8.0
             constrain_mode = "SETTLE"
-            gromacs_top = "{top_path}"
-            gromacs_gro = "{gro_path}"
-            default_out_file_prefix = "{tmp_path / "direct_feature"}"
+            gromacs_top = {_toml_string(top_path)}
+            gromacs_gro = {_toml_string(gro_path)}
+            default_out_file_prefix = {_toml_string(tmp_path / "direct_feature")}
             print_zeroth_frame = 1
             write_mdout_interval = 1
             """

--- a/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_features.py
+++ b/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_features.py
@@ -1,0 +1,129 @@
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def _gro_atom(resid, resname, atomname, atomnr, xyz):
+    x, y, z = xyz
+    return (
+        f"{resid:5d}{resname:<5}{atomname:>5}{atomnr:5d}"
+        f"{x:8.3f}{y:8.3f}{z:8.3f}"
+    )
+
+
+def test_direct_gromacs_topgro_accepts_settles_constraints_and_cmap(tmp_path):
+    top_path = tmp_path / "topol.top"
+    gro_path = tmp_path / "conf.gro"
+    mdin_path = tmp_path / "mdin.spg.toml"
+
+    top_path.write_text(
+        textwrap.dedent(
+            """
+            [ defaults ]
+            1 2 yes 0.5 0.833333
+
+            [ atomtypes ]
+            OW OW 15.9994 -0.834 A 0.315075 0.636386
+            HW HW 1.008 0.417 A 0.0 0.0
+            CT CT 12.011 0.0 A 0.34 0.276144
+
+            [ cmaptypes ]
+            CT CT CT CT CT 1 2 2 0.0 0.0 0.0 0.0
+
+            [ moleculetype ]
+            SOL 2
+
+            [ atoms ]
+            1 OW 1 SOL OW 1 -0.834 15.9994
+            2 HW 1 SOL HW1 2 0.417 1.008
+            3 HW 1 SOL HW2 3 0.417 1.008
+
+            [ settles ]
+            1 1 0.09572 0.15139
+
+            [ moleculetype ]
+            LIN 1
+
+            [ atoms ]
+            1 CT 1 LIN C1 1 0.0 12.011
+            2 CT 1 LIN C2 2 0.0 12.011
+
+            [ constraints ]
+            1 2 1 0.150
+
+            [ moleculetype ]
+            CMAP 1
+
+            [ atoms ]
+            1 CT 1 CMP C1 1 0.0 12.011
+            2 CT 1 CMP C2 2 0.0 12.011
+            3 CT 1 CMP C3 3 0.0 12.011
+            4 CT 1 CMP C4 4 0.0 12.011
+            5 CT 1 CMP C5 5 0.0 12.011
+
+            [ cmap ]
+            1 2 3 4 5 1
+
+            [ system ]
+            direct feature smoke
+
+            [ molecules ]
+            SOL 1
+            LIN 1
+            CMAP 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+    gro_lines = [
+        "direct feature smoke",
+        "10",
+        _gro_atom(1, "SOL", "OW", 1, (0.000, 0.000, 0.000)),
+        _gro_atom(1, "SOL", "HW1", 2, (0.096, 0.000, 0.000)),
+        _gro_atom(1, "SOL", "HW2", 3, (-0.024, 0.093, 0.000)),
+        _gro_atom(2, "LIN", "C1", 4, (0.500, 0.000, 0.000)),
+        _gro_atom(2, "LIN", "C2", 5, (0.650, 0.000, 0.000)),
+        _gro_atom(3, "CMP", "C1", 6, (1.000, 0.000, 0.000)),
+        _gro_atom(3, "CMP", "C2", 7, (1.150, 0.050, 0.020)),
+        _gro_atom(3, "CMP", "C3", 8, (1.300, 0.000, 0.070)),
+        _gro_atom(3, "CMP", "C4", 9, (1.450, -0.040, 0.030)),
+        _gro_atom(3, "CMP", "C5", 10, (1.600, 0.020, -0.050)),
+        "   5.00000   5.00000   5.00000",
+    ]
+    gro_path.write_text("\n".join(gro_lines) + "\n")
+
+    mdin_path.write_text(
+        textwrap.dedent(
+            f"""
+            md_name = "direct_gromacs_feature_smoke"
+            mode = "nve"
+            step_limit = 0
+            dt = 0
+            cutoff = 8.0
+            constrain_mode = "SETTLE"
+            gromacs_top = "{top_path}"
+            gromacs_gro = "{gro_path}"
+            default_out_file_prefix = "{tmp_path / "direct_feature"}"
+            print_zeroth_frame = 1
+            write_mdout_interval = 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+    result = subprocess.run(
+        [os.environ.get("SPONGE_BIN", "SPONGE"), "-mdin", str(mdin_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stdout + "\n" + result.stderr
+    output = result.stdout + "\n" + result.stderr
+    assert "constrain pair number is 4" in output
+    assert "rigid triangle numbers is 1" in output
+    assert "rigid pair numbers is 1" in output

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,6 +30,27 @@ China mirror:
 powershell -ExecutionPolicy ByPass -c "irm https://conda.spongemm.cn/pixi/install.ps1 | iex"
 ```
 
+## Install from binary distributions
+
+If you want to use a prebuilt SPONGE binary, install one of the published
+packages instead of building from source.
+
+### Choose a package
+
+| Package | Hardware | Platforms |
+|---------|----------|-----------|
+| `sponge-cuda13` | NVIDIA GPU (driver >= 570) | Linux x86_64, Windows x64 |
+| `sponge-cuda12` | NVIDIA GPU (driver >= 525) | Linux x86_64, Windows x64 |
+| `sponge-cpu` | CPU only | Linux x86_64 / aarch64, Windows x64, macOS ARM64 |
+| `sponge-cpu-mpi` | CPU + MPI | Linux x86_64 / aarch64 |
+
+### Install with pixi global
+
+```bash
+pixi project channel add https://conda.spongemm.cn
+pixi add sponge-xxx
+```
+
 ## Build SPONGE
 
 ### Choose an environment

--- a/docs/input-reference/README.md
+++ b/docs/input-reference/README.md
@@ -15,6 +15,7 @@ SPONGE -mdin mdin.spg.toml
 - [Constraints](constraint.md) — SETTLE / SHAKE
 - [Neighbor List](neighbor-list.md) — neighbor list configuration
 - [PME Electrostatics](pme.md) — Particle Mesh Ewald
+- [Collective Variables](collective-variables.md) — CV definitions and examples
 - [Enhanced Sampling](enhanced-sampling.md) — CV, MetaD, SITS
 - [SinkMeta](sinkmeta.md) — detailed `meta` / SinkMeta parameter reference
 - [Advanced](advanced.md) — device, wall constraints, ReaxFF, plugins

--- a/docs/input-reference/README.md
+++ b/docs/input-reference/README.md
@@ -12,6 +12,7 @@ SPONGE -mdin mdin.spg.toml
 - [Input/Output](io.md) — file specification and output control
 - [Thermostat](thermostat.md) — thermostat algorithms and parameters
 - [Barostat](barostat.md) — barostat algorithms and parameters
+- [Restrain](restrain.md) — atom-coordinate restrain input
 - [Constraints](constraint.md) — SETTLE / SHAKE
 - [Neighbor List](neighbor-list.md) — neighbor list configuration
 - [PME Electrostatics](pme.md) — Particle Mesh Ewald
@@ -32,11 +33,13 @@ dt = 0.002
 cutoff = 8.0
 default_in_file_prefix = "WAT"
 constrain_mode = "SHAKE"
-thermostat = "middle_langevin"
-thermostat_tau = 0.1
-thermostat_seed = 2026
 target_temperature = 300.0
 write_information_interval = 1000
+
+[thermostat]
+mode = "middle_langevin"
+tau = 0.1
+seed = 2026
 ```
 
 ### NPT
@@ -49,15 +52,19 @@ dt = 0.002
 cutoff = 8.0
 default_in_file_prefix = "WAT"
 constrain_mode = "SHAKE"
-thermostat = "middle_langevin"
-thermostat_tau = 0.1
-thermostat_seed = 2026
 target_temperature = 300.0
-barostat = "andersen_barostat"
-barostat_tau = 0.1
-barostat_update_interval = 10
 target_pressure = 1.0
 write_information_interval = 1000
+
+[thermostat]
+mode = "middle_langevin"
+tau = 0.1
+seed = 2026
+
+[barostat]
+mode = "andersen_barostat"
+tau = 0.1
+update_interval = 10
 ```
 
 ### Energy Minimization

--- a/docs/input-reference/advanced.md
+++ b/docs/input-reference/advanced.md
@@ -7,21 +7,117 @@
 | `device` | string | auto-detected | GPU device ID |
 | `device_optimized_block` | int | - | GPU block size optimization |
 
+## Domain Decomposition
+
+MPI domain decomposition parameters are read from the `[DOM_DEC]` scope:
+
+```toml
+[DOM_DEC]
+update_interval = 100
+split_nx = 2
+split_ny = 2
+split_nz = 1
+```
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `update_interval` | `DOM_DEC` | int | `100` | Domain-decomposition refresh interval |
+| `split_nx` | `DOM_DEC` | int | auto | Number of splits in X |
+| `split_ny` | `DOM_DEC` | int | auto | Number of splits in Y |
+| `split_nz` | `DOM_DEC` | int | auto | Number of splits in Z |
+
+When the split counts are omitted, SPONGE chooses them automatically from the
+PP MPI size and box geometry. Current MPI domain decomposition only supports
+orthogonal boxes.
+
+## Minimization
+
+Minimization-specific parameters use the `[minimization]` scope:
+
+```toml
+mode = "minimization"
+
+[minimization]
+dynamic_dt = 1
+max_move = 0.1
+beta1 = 0.9
+epsilon = 1e-4
+```
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `dynamic_dt` | `minimization` | int | `1` | Use the ADAM-like dynamic-step minimizer |
+| `max_move` | `minimization` | float | `0.1` | Maximum coordinate displacement per step in angstrom |
+| `momentum_keep` | `minimization` | float | `0.0` when `dynamic_dt = 0` | Momentum retention factor in gradient-descent mode |
+| `beta1` | `minimization` | float | `0.9` | First ADAM parameter used when `dynamic_dt != 0` |
+| `beta2` | `minimization` | float | `0.9` in the current source | Second ADAM parameter used when `dynamic_dt != 0` |
+| `epsilon` | `minimization` | float | `1e-4` | Numerical stabilizer used when `dynamic_dt != 0` |
+
+When `dynamic_dt != 0`, SPONGE internally resets `dt` to `3e-4 ps`. When
+`dynamic_dt = 0`, it uses a tiny fixed `dt` and the gradient-descent path.
+
+## Rerun Mode
+
+`rerun` uses the normal top-level trajectory file keys plus several
+rerun-specific flat keys:
+
+```toml
+mode = "rerun"
+crd = "traj.dat"
+box = "traj.box"
+vel = "traj.vel"
+frame_limit = 1000
+rerun_start = 0
+rerun_strip = 0
+rerun_need_box_update = 0
+```
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `crd` | `top-level` | string | required | Input coordinate trajectory for rerun |
+| `box` | `top-level` | string | required | Input box trajectory for rerun |
+| `vel` | `top-level` | string | optional | Input velocity trajectory for rerun |
+| `frame_limit` | `top-level` | int | - | Maximum number of rerun frames |
+| `rerun_frame_limit` | `top-level` | int | alias of `frame_limit` | Compatibility alias |
+| `rerun_start` | `top-level` | int | `0` | Starting frame offset |
+| `rerun_strip` | `top-level` | int | `0` | Number of frames skipped between processed frames |
+| `rerun_need_box_update` | `top-level` | int | `0` | Whether to update the box deformation tensor during rerun |
+
+The current source uses flat `rerun_*` keys rather than a `[rerun]` TOML
+section.
+
 ## Wall Constraints
 
 ### Hard Walls
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `hard_wall_x_low` / `hard_wall_x_high` | float | Hard wall position in X direction (A) |
-| `hard_wall_y_low` / `hard_wall_y_high` | float | Hard wall position in Y direction (A) |
-| `hard_wall_z_low` / `hard_wall_z_high` | float | Hard wall position in Z direction (A) |
+Hard-wall limits are configured through the `[hard_wall]` prefix:
+
+```toml
+[hard_wall]
+x_low = 0.0
+x_high = 40.0
+```
+
+| Parameter | Scope | Type | Description |
+|-----------|-------|------|-------------|
+| `x_low`, `x_high` | `hard_wall` | float | Hard-wall position in the X direction |
+| `y_low`, `y_high` | `hard_wall` | float | Hard-wall position in the Y direction |
+| `z_low`, `z_high` | `hard_wall` | float | Hard-wall position in the Z direction |
+
+Hard walls cannot be used in `npt` mode.
 
 ### Soft Walls
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `soft_walls_in_file` | string | Soft wall potential parameter file path |
+Soft walls are enabled by providing a configuration file:
+
+```toml
+[soft_walls]
+in_file = "soft_walls.txt"
+```
+
+| Parameter | Scope | Type | Description |
+|-----------|-------|------|-------------|
+| `in_file` | `soft_walls` | string | Soft-wall configuration file path |
 
 ## ReaxFF Reactive Force Field
 
@@ -38,16 +134,73 @@ type_in_file = "atom_types.txt"
 | `in_file` | string | ReaxFF parameter file |
 | `type_in_file` | string | Atom type mapping file |
 
+## Generalized Born
+
+Generalized Born parameters are configured through the `[gb]` scope:
+
+```toml
+[gb]
+in_file = "gb.txt"
+epsilon = 78.5
+radii_offset = 0.09
+radii_cutoff = 25.0
+```
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `in_file` | `gb` | string | - | Native GB parameter file |
+| `epsilon` | `gb` | float | `78.5` | Relative dielectric constant |
+| `radii_offset` | `gb` | float | `0.09` | Offset subtracted from self radii |
+| `radii_cutoff` | `gb` | float | `cutoff` | Cutoff used when building effective Born radii |
+
+## LJ Soft Core
+
+If a native soft-core LJ parameter file is provided through
+`LJ_soft_core_in_file`, SPONGE also reads several top-level alchemical
+parameters:
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `lambda_lj` | `top-level` | float | required | Soft-core LJ coupling parameter |
+| `soft_core_alpha` | `top-level` | float | `0.5` | Soft-core alpha parameter |
+| `soft_core_powfer` | `top-level` | float | `1.0` | Soft-core power parameter |
+| `soft_core_sigma` | `top-level` | float | `3.0` | Soft-core sigma parameter |
+| `soft_core_sigma_min` | `top-level` | float | `0.0` | Lower bound for the effective sigma term |
+
+These keys are top-level in the current source, not nested under
+`[LJ_soft_core]`.
+
 ## Custom Forces
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `custom_force` | section | Custom force configuration |
-| `pairwise_force` | section | Custom pairwise force configuration |
+| Parameter | Scope | Type | Description |
+|-----------|-------|------|-------------|
+| `in_file` | `pairwise_force` | string | Pairwise-force configuration file |
+| `in_file` | `listed_forces` | string | Listed-force configuration file |
+
+## Output Mapping For Periodic Molecules
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `force_whole_output` | `top-level` | bool | `false` | Force whole-molecule output mapping for periodic systems |
+| `make_output_whole` | `top-level` | string | - | Extra connectivity edges written as `atom_i-atom_j` pairs to help rebuild whole molecules |
+
+These keys are only meaningful when `pbc = true`.
+
+## Solvent LJ Shortcut
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `solvent_LJ` | `top-level` | bool | auto | Enable the water-specific solvent LJ shortcut |
+
+On GPU builds, if `solvent_LJ` is omitted, SPONGE may enable it automatically
+for suitable water-only tail residues. Setting the key explicitly overrides that
+heuristic.
 
 ## Plugins
 
-External plugins (e.g., PRIPS) are configured via the `[plugin]` section.
+Plugins are configured by the top-level key `plugin`, which is a whitespace-
+separated list of shared-library paths. This is not currently a TOML table
+interface.
 
 ## Control Parameters
 

--- a/docs/input-reference/barostat.md
+++ b/docs/input-reference/barostat.md
@@ -1,65 +1,141 @@
 # Barostat Parameters
 
+SPONGE requires a barostat in `npt` mode.
+
+For TOML input, prefer the grouped form:
+
+```toml
+mode = "npt"
+target_pressure = 1.0
+
+[barostat]
+mode = "andersen_barostat"
+tau = 0.1
+update_interval = 10
+```
+
+The parser also accepts the flat compatibility keys `barostat`,
+`barostat_tau`, `barostat_update_interval`, and similar `barostat_*` keys, but
+new documentation should use grouped TOML form.
+
 ## Barostat Selection
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `barostat` | string | **required for NPT** | Barostat algorithm |
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `mode` | `barostat` | string | required for NPT | Barostat algorithm |
 
-`barostat` options:
+Supported values:
 
 | Value | Description |
 |-------|-------------|
-| `"andersen_barostat"` | Andersen barostat |
-| `"berendsen_barostat"` | Berendsen barostat |
-| `"bussi_barostat"` | Bussi barostat |
+| `"andersen_barostat"` | Pressure-based Andersen barostat |
+| `"berendsen_barostat"` | Pressure-based Berendsen barostat |
+| `"bussi_barostat"` | Pressure-based Bussi barostat |
 | `"monte_carlo_barostat"` | Monte Carlo barostat |
 
-## Common Parameters
+## Top-level Parameters
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `target_pressure` | float | `1.0` | Target pressure (bar) |
-| `barostat_tau` | float | - | Coupling time constant (ps) |
-| `barostat_update_interval` | int | - | Barostat update interval (steps) |
-| `barostat_compressibility` | float | - | Isothermal compressibility (bar^-1) |
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `target_pressure` | `top-level` | float | `1.0` | Target pressure in bar |
+| `target_surface_tensor` | `top-level` | float | `0.0` | Target surface tension term used by pressure-based barostats |
 
-## Anisotropy Control
+`target_pressure` stays at the top level even when barostat options are written
+under `[barostat]`.
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `barostat_isotropy` / `isotropy` | string | `"isotropic"` | Pressure coupling type |
+## Pressure-based Barostats
 
-`barostat_isotropy` options:
+The algorithms `andersen_barostat`, `berendsen_barostat`, and `bussi_barostat`
+share the same parameter set.
+
+```toml
+[barostat]
+mode = "andersen_barostat"
+tau = 0.1
+compressibility = 4.5e-5
+update_interval = 10
+isotropy = "isotropic"
+```
+
+### Common Parameters
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `tau` | `barostat` | float | `1.0` | Barostat time constant (ps) |
+| `compressibility` | `barostat` | float | `4.5e-5` | Isothermal compressibility in `bar^-1` |
+| `update_interval` | `barostat` | int | `10` | Pressure-coupling update interval |
+| `isotropy` | `barostat` | string | `"isotropic"` | Pressure-coupling mode |
+
+Supported `isotropy` values:
 
 | Value | Description |
 |-------|-------------|
-| `"isotropic"` | Isotropic, uniform scaling on all axes |
-| `"semiisotropic"` | Semi-isotropic |
-| `"semianisotropic"` | Semi-anisotropic |
-| `"anisotropic"` | Anisotropic, independent scaling per axis |
+| `"isotropic"` | Uniform scaling on all axes |
+| `"semiisotropic"` | Semi-isotropic coupling |
+| `"semianisotropic"` | Semi-anisotropic coupling |
+| `"anisotropic"` | Fully anisotropic coupling |
 
-## Box Deformation Control
+### Box-deformation Parameters
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `barostat_g11` / `g21` / `g22` / `g31` / `g32` / `g33` | float | Box deformation matrix elements |
-| `barostat_x_constant` / `y_constant` / `z_constant` | float | Fix box size along a specific axis |
+| Parameter | Scope | Type | Description |
+|-----------|-------|------|-------------|
+| `g11`, `g21`, `g22`, `g31`, `g32`, `g33` | `barostat` | float | Initial box-velocity tensor elements |
+| `x_constant`, `y_constant`, `z_constant` | `barostat` | bool | Freeze box scaling on selected axes |
 
-## Surface Tension
+The `x_constant`, `y_constant`, and `z_constant` flags are booleans in the
+source code, not floats.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `surface_tensor` | string | Surface tension control mode |
-| `surface_number` | int | Number of surfaces |
-| `surface_tension` | float | Surface tension value |
+### Surface-tension Parameters
+
+Pressure-based barostats read the target surface term from the top-level key
+`target_surface_tensor`. The compatibility key `barostat_target_surface_tensor`
+is also accepted by the parser, but should not be the primary form shown in the
+documentation.
+
+## Monte Carlo Barostat
+
+`monte_carlo_barostat` uses a different parameter set and currently supports
+orthogonal boxes only.
+
+```toml
+[barostat]
+mode = "monte_carlo_barostat"
+
+[monte_carlo_barostat]
+initial_ratio = 0.001
+update_interval = 100
+check_interval = 10
+accept_rate_low = 30
+accept_rate_high = 40
+couple_dimension = "XYZ"
+```
+
+### Parameters
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `initial_ratio` | `monte_carlo_barostat` | float | `0.001` | Initial maximum fractional box-length move |
+| `update_interval` | `monte_carlo_barostat` | int | `100` | MC attempt interval |
+| `check_interval` | `monte_carlo_barostat` | int | `10` | Acceptance-rate adjustment interval |
+| `accept_rate_low` | `monte_carlo_barostat` | float | `30` | Lower target acceptance rate in percent |
+| `accept_rate_high` | `monte_carlo_barostat` | float | `40` | Upper target acceptance rate in percent |
+| `couple_dimension` | `monte_carlo_barostat` | string | `"XYZ"` | Coupled box dimensions |
+| `only_direction` | `monte_carlo_barostat` | string | - | Restrict moves within the selected coupling mode |
+| `surface_number` | `monte_carlo_barostat` | int | `0` | Number of surfaces, only used for non-`NO`/non-`XYZ` coupling |
+| `surface_tension` | `monte_carlo_barostat` | float | `0.0` | Surface tension, only used for non-`NO`/non-`XYZ` coupling |
+
+Supported `couple_dimension` values are `"XYZ"`, `"NO"`, `"XY"`, `"XZ"`, and
+`"YZ"`.
 
 ## Pressure Schedule
 
-Similar to temperature schedule, supports changing target pressure during simulation:
+Pressure schedules are controlled by top-level keys, not by `[barostat]`:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `target_pressure_schedule_mode` | string | `"step"` or `"linear"` |
-| `target_pressure_schedule_steps` | array | Inline schedule |
-| `target_pressure_schedule_file` | string | External schedule file path |
+| `target_pressure_schedule_steps` | array | Inline schedule: `[{ step = N, value = P }, ...]` |
+| `target_pressure_schedule_file` | string | Path to a TOML schedule file |
+
+Inline `target_pressure_schedule_steps` only works when the main mdin file is
+TOML.

--- a/docs/input-reference/collective-variables.md
+++ b/docs/input-reference/collective-variables.md
@@ -1,0 +1,363 @@
+# Collective Variables Guide
+
+SPONGE loads collective variable (CV) definitions from `cv_in_file` in
+`mdin.spg.toml`.
+
+```toml
+cv_in_file = "cv.toml"
+```
+
+If `cv_in_file` is not set, the CV controller is not initialized.
+
+## Supported file formats
+
+By default, CV files should be written in TOML.
+
+The file referenced by `cv_in_file` can be either:
+
+- a TOML file
+- a legacy block-style text file
+
+Both formats are flattened into the same internal command namespace, but TOML
+should be used for new documentation and new input files.
+
+### Recommended TOML format
+
+```toml
+[print]
+CV = ["phi", "psi"]
+
+[phi]
+CV_type = "dihedral"
+atom = [4, 6, 8, 14]
+
+[psi]
+CV_type = "dihedral"
+atom = [6, 8, 14, 16]
+```
+
+### Legacy block format
+
+The legacy block format is still supported for compatibility with existing
+cases:
+
+```text
+print
+{
+    CV = phi psi
+}
+phi
+{
+    CV_type = dihedral
+    atom = 4 6 8 14
+}
+psi
+{
+    CV_type = dihedral
+    atom = 6 8 14 16
+}
+```
+
+## Basic workflow
+
+1. Set `cv_in_file` in `mdin.spg.toml`.
+2. Define one or more CV modules in the CV file.
+3. Reference those CVs from `print`, `meta`, `steer`, `restrain`, or other
+   modules that consume CV names.
+4. Run SPONGE and inspect the corresponding output columns in `mdout`.
+
+## CV definitions
+
+Each CV is defined in a named module. The module name is how other sections
+refer to the CV.
+
+```toml
+[distance]
+CV_type = "distance"
+atom = [4, 6]
+```
+
+In this example:
+
+- `distance` is the CV module name
+- `CV_type = distance` selects the implementation
+- `atom = 4 6` provides the required atom indices
+
+## Built-in CV types
+
+| `CV_type` | Meaning | Required parameters |
+|-----------|---------|---------------------|
+| `position_x`, `position_y`, `position_z` | Cartesian coordinate of one atom | `atom` (1 atom) |
+| `scaled_position_x`, `scaled_position_y`, `scaled_position_z` | Fractional coordinate of one atom | `atom` (1 atom) |
+| `box_length_x`, `box_length_y`, `box_length_z` | Box length along one cell axis | none |
+| `distance` | Distance between two atoms | `atom` (2 atoms) |
+| `displacement_x`, `displacement_y`, `displacement_z` | Periodic displacement component between two atoms | `atom` (2 atoms) |
+| `angle` | Angle formed by three atoms | `atom` (3 atoms) |
+| `dihedral` | Dihedral angle formed by four atoms | `atom` (4 atoms) |
+| `combination` | Algebraic combination of other CVs | `CV`, `function` |
+| `tabulated` | Tabulated mapping of another CV with 4th-order B-spline interpolation | `CV`, `min`, `max`, `parameter` |
+| `rmsd` | RMSD to a reference structure | `atom` or `atom_in_file`; `coordinate` or `coordinate_in_file` |
+
+## RMSD CV
+
+`rmsd` evaluates the RMSD between a selected atom set and a reference
+coordinate set.
+
+The atom list and reference coordinates can be generated with
+`Xponge maskgen`.
+
+```toml
+[rmsd_ala]
+CV_type = "rmsd"
+atom_in_file = "rmsd_atoms.txt"
+coordinate_in_file = "rmsd_ref.txt"
+rotate = true
+```
+
+`rotate = true` enables optimal rotational alignment before RMSD evaluation.
+
+Parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `atom` | int list | Atom list |
+| `atom_in_file` | file | Atom list file |
+| `coordinate` | float list | Reference coordinates |
+| `coordinate_in_file` | file | Reference coordinate file |
+| `rotate` | bool | Whether to align the reference before RMSD evaluation |
+
+## Combination CV
+
+`combination` combines one or more CVs into a new value through a JIT-compiled
+expression.
+
+Example:
+
+```toml
+[lx]
+CV_type = "box_length_x"
+
+[ly]
+CV_type = "box_length_y"
+
+[lz]
+CV_type = "box_length_z"
+
+[example_CV]
+CV_type = "combination"
+CV = ["lx", "ly", "lz"]
+function = "lx * ly * lz"
+```
+
+The names used inside `function` must match the CV names listed in `CV`.
+
+When the expression contains floating-point literals, prefer single-precision
+suffixes such as `1.0f`. If the expression is compiled as a floating-point
+expression but integer literals are used directly, the JIT compiler may fail.
+
+Parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CV` | CV list | CVs used in the combination |
+| `function` | string | Expression used to combine the CVs |
+
+Supported operators and functions:
+
+| Meaning | Syntax | Meaning | Syntax |
+|---------|--------|---------|--------|
+| `a + b` | `a + b` | `a - b` | `a - b` |
+| `a * b` | `a * b` | `a / b` | `a / b` |
+| `a` to the power `b` | `powf(a)(b)` | natural logarithm of `a` | `logf(a)` |
+| `exp(a)` | `expf(a)` | complementary error function | `erfcf(a)` |
+| square root of `a` | `sqrtf(a)` | cosine of `a` | `cosf(a)` |
+| sine of `a` | `sinf(a)` | tangent of `a` | `tanf(a)` |
+| arccosine of `a` | `acosf(a)` | arcsine of `a` | `asinf(a)` |
+| arctangent of `a` | `atanf(a)` | absolute value of `a` | `fabsf(a)` |
+| larger of `a` and `b` | `fmaxf(a)(b)` | smaller of `a` and `b` | `fminf(a)(b)` |
+
+## Tabulated CV
+
+`tabulated` applies a tabulated mapping to another CV. Intermediate values are
+evaluated through 4th-order B-spline interpolation.
+
+Example:
+
+```toml
+[lx]
+CV_type = "box_length_x"
+
+[example_CV]
+CV_type = "tabulated"
+CV = "lx"
+min = 0.0
+max = 100.0
+parameter = [1.0, 4.0, 0.2, 7.0, 9.1, -11.0]
+min_padding = 1.1
+max_padding = 7.7
+```
+
+This example corresponds to the following table:
+
+| CV value | -60 | -40 | -20 | 0 | 20 | 40 | 60 | 80 | 100 | 120 | 140 | 160 |
+|----------|-----|-----|-----|---|----|----|----|----|-----|-----|-----|-----|
+| mapped value | 1.1 | 1.1 | 1.1 | 1.0 | 4.0 | 0.2 | 7.0 | 9.1 | -11.0 | 7.7 | 7.7 | 7.7 |
+
+Parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CV` | CV | CV to be interpolated |
+| `min` | float | Minimum CV value |
+| `max` | float | Maximum CV value |
+| `parameter` | float list | Tabulated mapped values |
+| `parameter_in_file` | file | File containing the mapped values |
+| `min_padding` | float | Fill value used below `min`, only for interpolation |
+| `max_padding` | float | Fill value used above `max`, only for interpolation |
+
+## Virtual atoms in CV files
+
+CV files can define CV-local virtual atoms and then reuse them in later CVs.
+This is useful for center-of-mass-based CVs in metadynamics.
+
+```toml
+[ML]
+vatom_type = "center_of_mass"
+atom_in_file = "ligand.list"
+
+[cx]
+CV_type = "position_x"
+atom = "ML"
+```
+
+In this example, `ML` is not a CV. It is a named virtual atom that can be used
+where an atom index would normally appear.
+
+## Printing CV values
+
+Use the `print` module to append CV values to SPONGE step output.
+
+```toml
+[print]
+CV = ["phi", "psi"]
+```
+
+Each printed CV appears under its module name. Avoid reusing names that already
+exist as built-in output columns.
+
+Parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CV` | CV list | CVs to print |
+
+## Restrain
+
+`restrain` applies a harmonic bias potential:
+
+$$
+U_{\rm bias} = \sum_{CV}{\rm weight} * (CV - {\rm reference})^2
+$$
+
+The restrain weight can vary with simulation step.
+
+If `start_step` and `max_step` are non-zero while `reduce_step` and
+`stop_step` are zero, the weight ramps up linearly from 0 to `weight`.
+
+```text
+           Harmonic weight
+                ↑
+          weight|         +-------------
+                |        /
+                |       /
+                |      /
+                0-----+---+------------>simulation step
+                   start max
+```
+
+If `start_step` and `max_step` are zero while `reduce_step` and `stop_step`
+are non-zero, the weight stays at `weight` first and then ramps down linearly
+to 0.
+
+```text
+           Harmonic weight
+                ↑
+          weight|----------------+
+                |                 \
+                |                  \
+                |                   \
+                0---------------+----+-->simulation step
+                             reduce stop
+```
+
+If all four step parameters are non-zero, the weight ramps up, stays at the
+maximum value, and then ramps down again.
+
+```text
+           Harmonic weight
+                ↑
+          weight|         +------+
+                |        /        \
+                |       /          \
+                |      /            \
+                0-----+---+-----+----+-->simulation step
+                   start max reduce stop
+```
+
+Parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CV` | CV list | CVs to restrain |
+| `weight` | float list | Bias weight |
+| `reference` | float list | Reference value |
+| `period` | float list | Period of the CV |
+| `start_step` | int list | Step at which `weight` starts increasing linearly |
+| `max_step` | int list | Step at which `weight` reaches the maximum |
+| `reduce_step` | int list | Step at which `weight` starts decreasing linearly |
+| `stop_step` | int list | Step at which `weight` becomes 0 |
+
+## Steer
+
+`steer` applies a linear bias potential:
+
+$$
+U_{\rm bias} = \sum_{CV} {\rm weight} * CV
+$$
+
+Parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CV` | CV list | CVs to bias |
+| `weight` | float list | Bias weight |
+
+## Typical examples
+
+### Dihedral CVs for SITS or analysis
+
+```toml
+[print]
+CV = ["phi", "psi"]
+
+[phi]
+CV_type = "dihedral"
+atom = [4, 6, 8, 14]
+
+[psi]
+CV_type = "dihedral"
+atom = [6, 8, 14, 16]
+```
+
+
+## Relationship to enhanced sampling modules
+
+- `cv_in_file` only tells SPONGE where to read CV definitions.
+- `meta` consumes CV names and adds metadynamics-specific parameters such as
+  `CV_sigma`, `CV_grid`, and `CV_period`.
+- SITS also consumes CV names, but its own control parameters live in
+  `mdin.spg.toml`.
+
+For parameter-by-parameter reference, see
+[Enhanced Sampling Parameters](enhanced-sampling.md) and
+[SinkMeta](sinkmeta.md).

--- a/docs/input-reference/collective-variables.md
+++ b/docs/input-reference/collective-variables.md
@@ -66,6 +66,9 @@ psi
    modules that consume CV names.
 4. Run SPONGE and inspect the corresponding output columns in `mdout`.
 
+This page documents CV-side `restrain`, which is different from the atom-
+coordinate restrain module documented in [restrain.md](restrain.md).
+
 ## CV definitions
 
 Each CV is defined in a named module. The module name is how other sections

--- a/docs/input-reference/constraint.md
+++ b/docs/input-reference/constraint.md
@@ -13,14 +13,32 @@
 | `"SETTLE"` | SETTLE algorithm, specialized for rigid water molecules (triangle constraints) |
 | `"SHAKE"` | SHAKE algorithm, general bond length constraints |
 
+The base constraint list is configured through the `[constrain]` prefix:
+
+```toml
+constrain_mode = "SHAKE"
+
+[constrain]
+mass = 3.3
+```
+
 ## SETTLE Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `settle_disable` | bool | `false` | Disable SETTLE |
+| `settle_disable` | bool | `false` | Top-level flag that disables SETTLE entirely |
 
 ## SHAKE Parameters
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `SHAKE_step_length` | float | - | SHAKE iteration convergence parameter |
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `iteration_numbers` | `SHAKE` | int | `25` | Maximum SHAKE iteration count |
+| `step_length` | `SHAKE` | float | `1.0` | SHAKE step length / damping factor |
+
+## `[constrain]` Parameters
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `in_file` | `constrain` | string | - | Extra bond-constraint list file |
+| `mass` | `constrain` | float | `3.3`, or `0.0` when `in_file` is set | Auto-constrain bonds involving atoms lighter than this threshold |
+| `angle` | `constrain` | bool | `false` | Reserved, currently not implemented |

--- a/docs/input-reference/core.md
+++ b/docs/input-reference/core.md
@@ -22,6 +22,15 @@
 | `"minimization"` / `"min"` | Energy minimization |
 | `"rerun"` | Trajectory reanalysis |
 
+## Periodic Boundary Conditions
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `pbc` | bool | `true` | Enable periodic boundary conditions |
+
+If `pbc = false`, SPONGE switches to the no-PBC path. This cannot be used with
+`npt`, is not supported in multi-process mode, and expects a very large box.
+
 ## Time and Steps
 
 | Parameter | Type | Default | Description |
@@ -41,10 +50,15 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `target_temperature` | float | `300.0` | Target temperature (K), required for NVT/NPT |
-| `target_pressure` | float | `1.0` | Target pressure (bar), required for NPT |
+| `target_temperature` | float | `300.0` | Top-level target temperature (K), used in NVT/NPT |
+| `target_pressure` | float | `1.0` | Top-level target pressure (bar), used in NPT |
 
-Temperature and pressure support schedules (step/linear changes). See [Thermostat](thermostat.md) and [Barostat](barostat.md).
+These two keys stay at the top level even when thermostat and barostat options are
+written in `[thermostat]` and `[barostat]`.
+
+Temperature and pressure also support schedules through the top-level keys
+`target_temperature_schedule_*` and `target_pressure_schedule_*`. See
+[Thermostat](thermostat.md) and [Barostat](barostat.md).
 
 ## Working Directory
 

--- a/docs/input-reference/enhanced-sampling.md
+++ b/docs/input-reference/enhanced-sampling.md
@@ -12,12 +12,6 @@ compatibility. See
 [Collective Variables Guide](collective-variables.md) for the supported CV
 types, virtual atoms, printing, and complete examples.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `CV_type` | string | CV type |
-| `CV_period` | int | CV update frequency |
-| `CV_minimal` / `CV_maximum` | float | CV value range |
-
 ## Metadynamics
 
 Configured via `[META]` or `[meta]` section:
@@ -30,22 +24,52 @@ Detailed SinkMeta parameter list: [sinkmeta.md](sinkmeta.md)
 
 ## SITS
 
-SITS (Self-guided Integrated Tempering Sampling) parameters:
+SITS parameters live under the `[SITS]` scope:
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `SITS_mode` | string | Run mode |
-| `SITS_atom_numbers` | int | Number of atoms participating in SITS |
-| `SITS_k_numbers` | int | Number of k-space points |
-| `SITS_T_low` / `SITS_T_high` | float | Temperature range (K) |
-| `SITS_record_interval` | int | Record interval |
-| `SITS_update_interval` | int | Update interval |
-| `SITS_nk_fix` | int | Fixed k-space point count |
-| `SITS_nk_in_file` | string | k-space input file |
-| `SITS_pe_a` / `SITS_pe_b` | float | Potential energy parameters |
-| `SITS_fb_interval` | int | Feedback interval |
+```toml
+[SITS]
+mode = "iteration"
+atom_numbers = "ALL"
+k_numbers = 40
+T_low = 300.0
+T_high = 600.0
+record_interval = 1
+update_interval = 100
+```
 
-`SITS_mode` options:
+### Common Parameters
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `mode` | `SITS` | string | required | SITS run mode |
+| `atom_in_file` | `SITS` | string | - | File-based atom partition definition for selective enhancement |
+| `atom_numbers` | `SITS` | int or string | required if `atom_in_file` is absent | Number of leading atoms in the selectively enhanced set, or `"ALL"` / `"ITS"` |
+| `cross_enhance_factor` | `SITS` | float | `0.5` | Enhancement factor for the cross term |
+| `fb_interval` | `SITS` | int | `1` | Feedback-bias update interval |
+
+Exactly one atom-selection method is required: `atom_in_file` or
+`atom_numbers`.
+
+### Iteration / Production Parameters
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `k_numbers` | `SITS` | int | `40` | Number of temperature points |
+| `T_low` | `SITS` | float | - | Lower temperature bound for generated ladder |
+| `T_high` | `SITS` | float | - | Upper temperature bound for generated ladder |
+| `T` | `SITS` | slash-separated string | - | Explicit temperature ladder used instead of `T_low` / `T_high` |
+| `record_interval` | `SITS` | int | `1` | Energy record interval |
+| `update_interval` | `SITS` | int | `100` | Parameter update interval |
+| `pe_a` | `SITS` | float | `1.0` | Multiplicative energy scaling factor |
+| `pe_b` | `SITS` | float | `0.0` | Additive energy offset |
+| `fb_bias` | `SITS` | float | `0.0` | Additional bias applied to `fb` |
+| `nk_rest` | `SITS` | bool | `false` in `iteration`, `true` otherwise | Whether to read restart `Nk` values |
+| `nk_in_file` | `SITS` | string | required when `nk_rest = true` or in `production` mode | Input file for restarting `Nk` |
+| `nk_fix` | `SITS` | bool | `false` in `iteration`, `true` otherwise | Freeze `Nk` during the run |
+| `nk_rest_file` | `SITS` | string | auto-generated | Output file for restart `Nk` values when `nk_fix = false` |
+| `nk_traj_file` | `SITS` | string | auto-generated | Output file for `Nk` history when `nk_fix = false` |
+
+`mode` options:
 
 | Value | Description |
 |-------|-------------|
@@ -55,3 +79,19 @@ SITS (Self-guided Integrated Tempering Sampling) parameters:
 | `"empirical"` | Empirical mode |
 | `"amd"` | AMD mode |
 | `"gamd"` | GaMD mode |
+
+### Empirical / AMD / GaMD Parameters
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `pe_a` | `SITS` | float | required in `amd` / `gamd`, `1.0` in `empirical` | Bias strength parameter |
+| `pe_b` | `SITS` | float | required in `amd` / `gamd`, `0.0` in `empirical` | Bias threshold parameter |
+| `T_low` | `SITS` | float | required in `empirical` | Lower temperature bound |
+| `T_high` | `SITS` | float | required in `empirical` | Upper temperature bound |
+
+Notes:
+
+- `amd`, `gamd`, and `empirical` do not use the full `k_numbers` / `Nk` update
+  workflow.
+- The current source reads `T` as a slash-separated string rather than a TOML
+  numeric array.

--- a/docs/input-reference/enhanced-sampling.md
+++ b/docs/input-reference/enhanced-sampling.md
@@ -6,7 +6,11 @@
 |-----------|------|-------------|
 | `cv_in_file` | string | Collective variable definition file path |
 
-CVs can also be defined inline via the `[CV]` section:
+CV definitions are loaded from the file pointed to by `cv_in_file`. New CV
+files should use TOML; the legacy block format remains supported for
+compatibility. See
+[Collective Variables Guide](collective-variables.md) for the supported CV
+types, virtual atoms, printing, and complete examples.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|

--- a/docs/input-reference/io.md
+++ b/docs/input-reference/io.md
@@ -1,5 +1,15 @@
 # Input/Output Parameters
 
+SPONGE has three mutually exclusive structure/topology input families:
+
+- native text inputs loaded by Xponge
+- AMBER inputs loaded from `amber_parm7` / `amber_rst7`
+- GROMACS inputs loaded from `gromacs_top` / `gromacs_gro`
+
+If either GROMACS key exists, SPONGE uses the GROMACS loader. Otherwise, if
+either AMBER key exists, SPONGE uses the AMBER loader. If neither family is
+selected, SPONGE falls back to native inputs.
+
 ## Input Files
 
 ### Common Prefix
@@ -18,7 +28,10 @@ Setting `default_in_file_prefix = "WAT"` causes SPONGE to look for:
 - `WAT_exclude.txt` — exclusion list
 - etc.
 
-### Individual Input Files
+### Native Input Files
+
+The native loader reads a family of `<module>_in_file` keys. The most common
+ones are:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -26,12 +39,23 @@ Setting `default_in_file_prefix = "WAT"` causes SPONGE to look for:
 | `velocity_in_file` | string | Velocity file path |
 | `mass_in_file` | string | Mass file path |
 | `charge_in_file` | string | Charge file path |
-| `atom_in_file` | string | Atom information file |
-| `atom_type_in_file` | string | Atom type file |
-| `edge_in_file` | string | Bond/edge information file |
-| `angle_in_file` | string | Angle information file |
-| `dihedral_in_file` | string | Dihedral information file |
-| `atom_numbers` | int | Total atom count (can be auto-detected from files) |
+| `residue_in_file` | string | Residue membership file |
+| `exclude_in_file` | string | Exclusion list file |
+| `bond_in_file` | string | Bond parameter file |
+| `angle_in_file` | string | Angle parameter file |
+| `dihedral_in_file` | string | Dihedral parameter file |
+| `improper_dihedral_in_file` | string | Improper dihedral file |
+| `cmap_in_file` | string | CMAP file |
+| `lj_in_file` | string | Lennard-Jones parameter file |
+| `LJ_soft_core_in_file` | string | Soft-core Lennard-Jones parameter file |
+| `nb14_in_file` | string | 1-4 interaction file |
+| `nb14_extra_in_file` | string | Extra 1-4 interaction file |
+| `urey_bradley_in_file` | string | Urey-Bradley file |
+| `virtual_atom_in_file` | string | Native virtual-atom definition file |
+
+Some modules add their own native files, for example `lj_soft_in_file`,
+`gb_in_file`, and module-specific `in_file` keys documented on their
+corresponding pages.
 
 ### External Format Import
 
@@ -41,18 +65,20 @@ Setting `default_in_file_prefix = "WAT"` causes SPONGE to look for:
 | `amber_rst7` | string | AMBER rst7 coordinate/velocity file |
 | `gromacs_gro` | string | GROMACS .gro coordinate file |
 | `gromacs_top` | string | GROMACS .top topology file |
+| `gromacs_include_dir` | string list | Extra include directories used when reading `.top` |
+| `gromacs_define` | string list | Extra preprocessor defines used when reading `.top` |
 
 ## Output Files
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `mdout` | string | `"mdout.txt"` | Standard output file (energy, temperature, etc.) |
-| `mdinfo` | string | `"mdinfo.txt"` | Simulation info/log file |
+| `mdout` | string | controller default or `default_out_file_prefix + ".out"` | Standard output file (energy, temperature, etc.) |
+| `mdinfo` | string | controller default or `default_out_file_prefix + ".info"` | Simulation info/log file |
 | `crd` | string | - | Coordinate trajectory file (binary) |
 | `vel` | string | - | Velocity trajectory file (binary) |
 | `frc` | string | - | Force trajectory file (binary) |
 | `box` | string | - | Box information trajectory file |
-| `rst` | string | - | Restart file |
+| `rst` | string | `SPONGE` or `default_out_file_prefix` | Restart filename prefix |
 
 ## Output Frequency Control
 
@@ -62,13 +88,16 @@ Setting `default_in_file_prefix = "WAT"` causes SPONGE to look for:
 | `write_mdout_interval` | int | `1000` | mdout write interval |
 | `write_trajectory_interval` | int | same as `write_information_interval` | Trajectory write interval |
 | `write_restart_file_interval` | int | `step_limit` | Restart file write interval |
-| `max_restart_export_count` | int | - | Maximum number of restart files to keep |
+| `max_restart_export_count` | int | `1` | Maximum number of restart files to keep in rotation |
 | `buffer_frame` | int | `10` | File buffer frame count (affects I/O performance) |
 
 ## Output Content Control
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `print_zeroth_frame` | int | `0` | Whether to output step 0 frame (1 = yes) |
-| `print_pressure` | int | `0` | Whether to output pressure |
-| `print_detail` | int | `0` | Detailed output level |
+| `print_zeroth_frame` | bool | `false` | Whether to output step 0 frame |
+| `print_pressure` | bool | `false` | Whether to append pressure and virial terms to `mdout` |
+
+`mdout` and `mdinfo` are controller-managed output files. Trajectory-related
+files are created only when the corresponding key exists or when the default
+coordinate/box trajectories are enabled by `write_trajectory_interval`.

--- a/docs/input-reference/neighbor-list.md
+++ b/docs/input-reference/neighbor-list.md
@@ -17,9 +17,7 @@ skin_permit = 0.5
 | `max_neighbor_numbers` | int | `1200` | Maximum neighbors per atom |
 | `max_atom_in_grid_numbers` | int | `150` | Maximum atoms per grid cell |
 | `max_ghost_in_grid_numbers` | int | `150` | Maximum ghost atoms per grid cell |
-| `max_padding` | int | - | Maximum array padding |
-| `min_padding` | int | - | Minimum array padding |
-| `check_overflow_interval` | int | - | Memory overflow check interval |
+| `check_overflow_interval` | int | `150` | Memory overflow check interval |
 | `throw_error_when_overflow` | bool | `false` | Whether to throw an error on overflow (otherwise auto-expands) |
 
 The rebuild strategy defaults to automatic detection based on `skin` distance. `refresh_interval = 0` enables automatic mode.

--- a/docs/input-reference/pme.md
+++ b/docs/input-reference/pme.md
@@ -1,21 +1,46 @@
 # PME Electrostatics Parameters
 
-PME (Particle Mesh Ewald) parameters are set via the `[PME]` TOML section:
+PME is initialized through the `PM` module in the current source tree, so new
+TOML examples should prefer the `[PM]` scope:
 
 ```toml
-[PME]
+[PM]
 grid_spacing = 1.0
+Direct_Tolerance = 1e-5
+MPI_size = 1
+print_detail = false
 ```
 
-## Parameter List
+Some PME control keys are still read from the compatibility scope `[PME]`. This
+is a source-level behavior, not a separate algorithm.
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `fftx` / `ffty` / `fftz` | int | auto | FFT grid dimensions |
-| `grid_spacing` | float | `1.0` | Grid spacing (A), used to auto-determine FFT dimensions |
-| `update_interval` | int | `1` | Reciprocal space summation update interval (steps) |
-| `Direct_Tolerance` | float | - | Direct space cutoff tolerance |
-| `calculate_excluded_part` | bool | - | Whether to compute excluded pair interactions |
-| `calculate_reciprocal_part` | bool | - | Whether to compute the reciprocal space part |
+## `[PM]` Parameters
 
-If `fftx/ffty/fftz` are not specified, SPONGE automatically calculates them from `grid_spacing` and the box dimensions.
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `fftx` | `PM` | int | auto | FFT grid size in X |
+| `ffty` | `PM` | int | auto | FFT grid size in Y |
+| `fftz` | `PM` | int | auto | FFT grid size in Z |
+| `grid_spacing` | `PM` | float | `1.0` | Grid spacing in angstrom |
+| `Direct_Tolerance` | `PM` | float | `1e-5` | Direct-space Ewald tolerance |
+| `MPI_size` | `PM` | int | controller value | PME process count |
+| `print_detail` | `PM` | bool | `false` | Print detailed PME energy breakdown |
+
+If `fftx`, `ffty`, and `fftz` are omitted, SPONGE derives them from
+`grid_spacing` and the current box dimensions.
+
+`MPI_size > 1` is currently rejected by the source code even if the key is
+present.
+
+## Compatibility Keys In `[PME]`
+
+The following keys are read from the `[PME]` scope in the current source:
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `update_interval` | `PME` | int | `1` | Reciprocal-space update interval |
+| `calculate_reciprocal_part` | `PME` | bool | `true` | Whether to compute reciprocal-space PME |
+| `calculate_excluded_part` | `PME` | bool | `true` | Whether to compute excluded-pair PME terms |
+| `replaced_by_PMC_IZ` | `PME` | bool | `false` | Replace PME reciprocal evaluation with PMC-IZ |
+
+`replaced_by_PMC_IZ = true` cannot be used in `npt` mode.

--- a/docs/input-reference/restrain.md
+++ b/docs/input-reference/restrain.md
@@ -1,0 +1,91 @@
+# Atom Restrain Parameters
+
+SPONGE has a coordinate restrain module that is separate from the CV-side
+`restrain` described in [collective-variables.md](collective-variables.md).
+
+This module is initialized directly in the main MD workflow and restrains a list
+of atoms to reference coordinates.
+
+## Input Style
+
+This module currently uses historical flat prefix keys such as
+`restrain_atom_id` and `restrain_single_weight`.
+
+The parser stores grouped TOML keys as `prefix_key`, so the following TOML form
+is equivalent and is preferred for new documentation:
+
+```toml
+[restrain]
+atom_id = "restrain_atom_id.txt"
+coordinate_in_file = "restrain_ref.txt"
+single_weight = 20.0
+refcoord_scaling = "com_mol"
+calc_virial = true
+```
+
+## Minimal Example
+
+```toml
+[restrain]
+atom_id = "restrain_atom_id.txt"
+coordinate_in_file = "restrain_ref.txt"
+single_weight = 20.0
+```
+
+If neither `coordinate_in_file` nor `amber_rst7` is provided, SPONGE copies the
+current input coordinates as the restrain reference.
+
+## Parameters
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `atom_id` | `restrain` | string | - | Required atom-list file; enables the module |
+| `coordinate_in_file` | `restrain` | string | current input coordinates | Reference coordinate file |
+| `amber_rst7` | `restrain` | string | - | Reference coordinates loaded from an AMBER rst7 file |
+| `single_weight` | `restrain` | float | `20.0` | Isotropic restrain weight applied to every restrained atom |
+| `weight_in_file` | `restrain` | string | - | Per-atom anisotropic restrain weights; used when `single_weight` is not set |
+| `refcoord_scaling` | `restrain` | string | `"no"` | How reference coordinates are scaled during box updates |
+| `calc_virial` | `restrain` | bool | `true` | Whether to accumulate restrain virial |
+
+## `refcoord_scaling`
+
+Supported values are:
+
+| Value | Meaning |
+|-------|---------|
+| `"no"` | Do not scale the reference |
+| `"all"` | Scale all reference coordinates with the box |
+| `"com_ug"` | Scale by unit-group center of mass |
+| `"com_res"` | Scale by residue center of mass |
+| `"com_mol"` | Scale by molecule center of mass |
+
+## Weight Input Modes
+
+### Isotropic Weight
+
+```toml
+[restrain]
+atom_id = "restrain_atom_id.txt"
+single_weight = 20.0
+```
+
+This applies one scalar force constant to every restrained atom.
+
+### Per-atom Anisotropic Weights
+
+```toml
+[restrain]
+atom_id = "restrain_atom_id.txt"
+weight_in_file = "restrain_weight.txt"
+```
+
+`weight_in_file` must contain one `wx wy wz` triplet per restrained atom.
+
+## Notes
+
+- The module is enabled only when `restrain_atom_id` or `atom_id` in the
+  `restrain` scope is present.
+- `coordinate_in_file` takes precedence over `amber_rst7`.
+- If `single_weight` is not provided, `weight_in_file` is expected.
+- This module is independent of CV `restrain`; both can be used in the same run
+  if needed.

--- a/docs/input-reference/thermostat.md
+++ b/docs/input-reference/thermostat.md
@@ -1,41 +1,151 @@
 # Thermostat Parameters
 
+SPONGE requires a thermostat in `nvt` and `npt` modes.
+
+For TOML input, prefer the grouped form:
+
+```toml
+mode = "nvt"
+target_temperature = 300.0
+
+[thermostat]
+mode = "middle_langevin"
+tau = 0.1
+seed = 2026
+```
+
+The parser also accepts the flat compatibility keys `thermostat`,
+`thermostat_tau`, and `thermostat_seed`, but new documentation should use the
+grouped TOML form above.
+
 ## Thermostat Selection
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `thermostat` | string | **required for NVT/NPT** | Thermostat algorithm |
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `mode` | `thermostat` | string | required for NVT/NPT | Thermostat algorithm |
 
-`thermostat` options:
+Supported values:
 
 | Value | Description |
 |-------|-------------|
-| `"middle_langevin"` / `"langevin"` | Middle Langevin dynamics (recommended) |
+| `"middle_langevin"` | Middle Langevin dynamics |
+| `"langevin"` | Deprecated alias of `middle_langevin` |
 | `"andersen"` | Andersen thermostat |
 | `"berendsen_thermostat"` | Berendsen thermostat |
-| `"bussi_thermostat"` | Bussi (velocity rescaling) thermostat |
+| `"bussi_thermostat"` | Bussi velocity-rescaling thermostat |
 | `"nose_hoover_chain"` | Nose-Hoover chain thermostat |
 
-## Common Parameters
+## Top-level Parameters
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `target_temperature` | float | `300.0` | Target temperature (K) |
-| `thermostat_tau` / `tau` | float | - | Coupling time constant (ps) |
-| `thermostat_seed` / `seed` | int | - | Random seed (required for stochastic thermostats) |
-| `velocity_max` | float | - | Maximum allowed velocity |
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `target_temperature` | `top-level` | float | `300.0` | Target temperature (K) |
+| `velocity_max` | `top-level` | float | disabled | Velocity cap used by some thermostats |
+
+`target_temperature` is not part of `[thermostat]`. It stays at the top level
+and is also the quantity affected by temperature schedules.
+
+## Common Thermostat Parameters
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `tau` | `thermostat` | float | `1.0` | Coupling time constant in ps |
+| `seed` | `thermostat` | int | random | Random seed for stochastic thermostats |
+
+Notes:
+
+- `seed` is used by `middle_langevin`, `andersen`, and `bussi_thermostat`
+- `berendsen_thermostat` and `nose_hoover_chain` do not read `seed`
+- `middle_langevin` converts `tau` internally to a friction coefficient
+  `gamma = 1 / tau`
+- `andersen` converts `tau` to an internal collision update interval
+
+## Algorithm-specific Parameters
+
+### `middle_langevin`
+
+```toml
+[thermostat]
+mode = "middle_langevin"
+tau = 0.1
+seed = 2026
+```
+
+Uses `tau` and `seed` in the `thermostat` scope, plus the top-level
+`velocity_max`.
+
+### `andersen`
+
+```toml
+[thermostat]
+mode = "andersen"
+tau = 0.1
+seed = 2026
+```
+
+Uses `tau` and `seed` in the `thermostat` scope, plus the top-level
+`velocity_max`.
+
+### `berendsen_thermostat`
+
+```toml
+[thermostat]
+mode = "berendsen_thermostat"
+tau = 0.1
+```
+
+Uses only `tau` in the `thermostat` scope.
+
+### `bussi_thermostat`
+
+```toml
+[thermostat]
+mode = "bussi_thermostat"
+tau = 0.1
+seed = 2026
+```
+
+Uses `tau` and `seed` in the `thermostat` scope.
+
+### `nose_hoover_chain`
+
+```toml
+[thermostat]
+mode = "nose_hoover_chain"
+tau = 0.2
+
+[nose_hoover_chain]
+length = 3
+restart_input = "nhc_restart.in"
+restart_output = "nhc_restart.out"
+crd = "nhc_crd.dat"
+vel = "nhc_vel.dat"
+```
+
+Additional parameters:
+
+| Parameter | Scope | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `length` | `nose_hoover_chain` | int | `1` | Chain length |
+| `restart_input` | `nose_hoover_chain` | string | - | Read initial chain state from file |
+| `restart_output` | `nose_hoover_chain` | string | - | Write chain state to file |
+| `crd` | `nose_hoover_chain` | string | - | Write chain coordinate trajectory |
+| `vel` | `nose_hoover_chain` | string | - | Write chain velocity trajectory |
+
+`nose_hoover_chain` also reads the top-level `velocity_max`.
 
 ## Temperature Schedule
 
-Supports changing target temperature during simulation:
+Temperature schedules are controlled by top-level keys, not by `[thermostat]`:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `target_temperature_schedule_mode` | string | `"step"` (step change) or `"linear"` (linear interpolation) |
-| `target_temperature_schedule_steps` | array | Inline schedule, format: `[{step = N, value = T}, ...]` |
-| `target_temperature_schedule_file` | string | External schedule file path (TOML format) |
+| `target_temperature_schedule_mode` | string | `"step"` or `"linear"` |
+| `target_temperature_schedule_steps` | array | Inline schedule: `[{ step = N, value = T }, ...]` |
+| `target_temperature_schedule_file` | string | Path to a TOML schedule file |
 
-Example:
+Inline `target_temperature_schedule_steps` only works when the main mdin file is
+TOML.
 
 ```toml
 target_temperature = 300.0


### PR DESCRIPTION
Closes #33

## Summary
- add binary distribution install instructions
- move CV documentation into `docs/input-reference/`
- expand RMSD, combination, tabulated, print, restrain, and steer documentation
- make TOML the default format for CV examples

## Validation
- `git diff --check`
