### PR TITLE
修复 AMBER NONBONDED_PARM_INDEX 的 Lennard-Jones 参数映射

### DIFF
--- a/SPONGE/xponge/load/amber.hpp
+++ b/SPONGE/xponge/load/amber.hpp
@@ -39,6 +39,152 @@ static void Amber_Require_Section_Size(const std::vector<std::string>& values,
     }
 }
 
+template <typename T>
+static void Amber_Require_Exact_Section_Size(const std::vector<T>& values,
+                                             std::size_t expected_count,
+                                             CONTROLLER* controller,
+                                             const char* error_by,
+                                             const char* section_name)
+{
+    if (values.size() != expected_count)
+    {
+        controller->Throw_Formatted_SPONGE_Error(
+            spongeErrorBadFileFormat, error_by,
+            "Reason:\n\tAMBER section %s has %zu values; expected %zu\n",
+            section_name, values.size(), expected_count);
+    }
+}
+
+static std::vector<int> Amber_Build_Canonical_Nonbonded_Map(
+    int atom_type_numbers, const std::vector<int>& nonbonded_parm_index,
+    bool has_nonbonded_parm_index, const std::vector<float>& hbond_pair_A,
+    const std::vector<float>& hbond_pair_B, CONTROLLER* controller,
+    const char* error_by)
+{
+    if (atom_type_numbers < 0)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorBadFileFormat, error_by,
+            "Reason:\n\tthe AMBER atom type count cannot be negative\n");
+    }
+
+    std::size_t type_numbers = static_cast<std::size_t>(atom_type_numbers);
+    std::size_t pair_type_numbers = type_numbers * (type_numbers + 1) / 2;
+    std::vector<int> source_index(pair_type_numbers, -1);
+    if (!has_nonbonded_parm_index)
+    {
+        if (atom_type_numbers > 1)
+        {
+            controller->Throw_SPONGE_Error(
+                spongeErrorBadFileFormat, error_by,
+                "Reason:\n\tNONBONDED_PARM_INDEX is required when AMBER "
+                "NTYPES is greater than 1\n");
+        }
+        for (std::size_t i = 0; i < pair_type_numbers; i++)
+        {
+            source_index[i] = static_cast<int>(i);
+        }
+        return source_index;
+    }
+
+    Amber_Require_Exact_Section_Size(nonbonded_parm_index,
+                                     type_numbers * type_numbers, controller,
+                                     error_by, "NONBONDED_PARM_INDEX");
+    for (int high = 0; high < atom_type_numbers; high++)
+    {
+        for (int low = 0; low <= high; low++)
+        {
+            int forward = nonbonded_parm_index[static_cast<std::size_t>(low) *
+                                                   type_numbers +
+                                               high];
+            int reverse = nonbonded_parm_index[static_cast<std::size_t>(high) *
+                                                   type_numbers +
+                                               low];
+            if (forward != reverse)
+            {
+                controller->Throw_Formatted_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tNONBONDED_PARM_INDEX is asymmetric for atom "
+                    "types %d and %d\n",
+                    low + 1, high + 1);
+            }
+            std::size_t canonical_index =
+                static_cast<std::size_t>(high) * (high + 1) / 2 + low;
+            if (forward > 0)
+            {
+                if (static_cast<std::size_t>(forward) > pair_type_numbers)
+                {
+                    controller->Throw_Formatted_SPONGE_Error(
+                        spongeErrorBadFileFormat, error_by,
+                        "Reason:\n\tNONBONDED_PARM_INDEX value %d for atom "
+                        "types %d and %d is outside [1, %zu]\n",
+                        forward, low + 1, high + 1, pair_type_numbers);
+                }
+                source_index[canonical_index] = forward - 1;
+                continue;
+            }
+            if (forward == 0)
+            {
+                controller->Throw_Formatted_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tNONBONDED_PARM_INDEX contains zero for atom "
+                    "types %d and %d\n",
+                    low + 1, high + 1);
+            }
+
+            long long hbond_index_value = -static_cast<long long>(forward) - 1;
+            if (hbond_index_value < 0 ||
+                static_cast<std::size_t>(hbond_index_value) >=
+                    hbond_pair_A.size() ||
+                static_cast<std::size_t>(hbond_index_value) >=
+                    hbond_pair_B.size())
+            {
+                controller->Throw_Formatted_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tNONBONDED_PARM_INDEX value %d for atom types "
+                    "%d and %d does not select a valid HBOND parameter\n",
+                    forward, low + 1, high + 1);
+            }
+            std::size_t hbond_index =
+                static_cast<std::size_t>(hbond_index_value);
+            if (hbond_pair_A[hbond_index] != 0.0f ||
+                hbond_pair_B[hbond_index] != 0.0f)
+            {
+                controller->Throw_Formatted_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tAMBER 10-12 nonbonded terms are not supported; "
+                    "atom types %d and %d select nonzero HBOND parameter %zu\n",
+                    low + 1, high + 1, hbond_index + 1);
+            }
+            source_index[canonical_index] = -1;
+        }
+    }
+    return source_index;
+}
+
+static void Amber_Remap_LJ_Pair_Matrix(
+    const std::vector<float>& raw_pair_A, const std::vector<float>& raw_pair_B,
+    const std::vector<int>& source_index, std::vector<float>* pair_A,
+    std::vector<float>* pair_B, CONTROLLER* controller, const char* error_by,
+    const char* section_A, const char* section_B)
+{
+    Amber_Require_Exact_Section_Size(raw_pair_A, source_index.size(),
+                                     controller, error_by, section_A);
+    Amber_Require_Exact_Section_Size(raw_pair_B, source_index.size(),
+                                     controller, error_by, section_B);
+    pair_A->assign(source_index.size(), 0.0f);
+    pair_B->assign(source_index.size(), 0.0f);
+    for (std::size_t i = 0; i < source_index.size(); i++)
+    {
+        int source = source_index[i];
+        if (source >= 0)
+        {
+            pair_A->at(i) = raw_pair_A.at(static_cast<std::size_t>(source));
+            pair_B->at(i) = raw_pair_B.at(static_cast<std::size_t>(source));
+        }
+    }
+}
+
 static int Amber_Get_Atom_Numbers(const System* system);
 static std::vector<std::string> Amber_Read_Section(
     const std::vector<std::string>& lines, std::size_t* index);
@@ -87,6 +233,7 @@ static void Amber_Load_Classical_Force_Field(System* system,
     int bond_type_numbers = 0;
     int angle_type_numbers = 0;
     int dihedral_type_numbers = 0;
+    int hbond_type_numbers = 0;
 
     std::vector<float> bond_type_k;
     std::vector<float> bond_type_r0;
@@ -97,6 +244,17 @@ static void Amber_Load_Classical_Force_Field(System* system,
     std::vector<float> dihedral_type_periodicity;
     std::vector<float> scee_scale_factor;
     std::vector<float> scnb_scale_factor;
+    std::vector<float> raw_lj_pair_A;
+    std::vector<float> raw_lj_pair_B;
+    std::vector<float> hbond_pair_A;
+    std::vector<float> hbond_pair_B;
+    std::vector<int> nonbonded_parm_index;
+
+    bool has_lj_pair_A = false;
+    bool has_lj_pair_B = false;
+    bool has_hbond_pair_A = false;
+    bool has_hbond_pair_B = false;
+    bool has_nonbonded_parm_index = false;
 
     std::vector<int> raw_dihedral_a;
     std::vector<int> raw_dihedral_b;
@@ -118,7 +276,7 @@ static void Amber_Load_Classical_Force_Field(System* system,
         if (current_flag == "POINTERS")
         {
             Amber_Require_Section_Size(
-                values, 18, controller,
+                values, 20, controller,
                 "Xponge::Amber_Load_Classical_Force_Field");
             atom_numbers = Amber_Parse_Int(values[0]);
             atom_type_numbers = Amber_Parse_Int(values[1]);
@@ -131,6 +289,14 @@ static void Amber_Load_Classical_Force_Field(System* system,
             bond_type_numbers = Amber_Parse_Int(values[15]);
             angle_type_numbers = Amber_Parse_Int(values[16]);
             dihedral_type_numbers = Amber_Parse_Int(values[17]);
+            hbond_type_numbers = Amber_Parse_Int(values[19]);
+            if (hbond_type_numbers < 0)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat,
+                    "Xponge::Amber_Load_Classical_Force_Field",
+                    "Reason:\n\tAMBER NPHB cannot be negative\n");
+            }
         }
         else if (current_flag == "BOND_FORCE_CONSTANT")
         {
@@ -358,33 +524,111 @@ static void Amber_Load_Classical_Force_Field(System* system,
                 ff->lj.atom_type[j] = Amber_Parse_Int(values[j]) - 1;
             }
         }
+        else if (current_flag == "NONBONDED_PARM_INDEX")
+        {
+            nonbonded_parm_index.resize(values.size());
+            for (std::size_t j = 0; j < values.size(); j++)
+            {
+                nonbonded_parm_index[j] = Amber_Parse_Int(values[j]);
+            }
+            has_nonbonded_parm_index = true;
+        }
+        else if (current_flag == "HBOND_ACOEF")
+        {
+            Amber_Require_Exact_Section_Size(
+                values, static_cast<std::size_t>(hbond_type_numbers),
+                controller, "Xponge::Amber_Load_Classical_Force_Field",
+                "HBOND_ACOEF");
+            hbond_pair_A.resize(hbond_type_numbers);
+            for (int j = 0; j < hbond_type_numbers; j++)
+            {
+                hbond_pair_A[j] = Amber_Parse_Float(values[j]);
+            }
+            has_hbond_pair_A = true;
+        }
+        else if (current_flag == "HBOND_BCOEF")
+        {
+            Amber_Require_Exact_Section_Size(
+                values, static_cast<std::size_t>(hbond_type_numbers),
+                controller, "Xponge::Amber_Load_Classical_Force_Field",
+                "HBOND_BCOEF");
+            hbond_pair_B.resize(hbond_type_numbers);
+            for (int j = 0; j < hbond_type_numbers; j++)
+            {
+                hbond_pair_B[j] = Amber_Parse_Float(values[j]);
+            }
+            has_hbond_pair_B = true;
+        }
         else if (current_flag == "LENNARD_JONES_ACOEF")
         {
             int pair_type_numbers =
                 atom_type_numbers * (atom_type_numbers + 1) / 2;
-            Amber_Require_Section_Size(
+            Amber_Require_Exact_Section_Size(
                 values, static_cast<std::size_t>(pair_type_numbers), controller,
-                "Xponge::Amber_Load_Classical_Force_Field");
-            ff->lj.pair_A.resize(pair_type_numbers);
+                "Xponge::Amber_Load_Classical_Force_Field",
+                "LENNARD_JONES_ACOEF");
+            raw_lj_pair_A.resize(pair_type_numbers);
             for (int j = 0; j < pair_type_numbers; j++)
             {
-                ff->lj.pair_A[j] = 12.0f * Amber_Parse_Float(values[j]);
+                raw_lj_pair_A[j] = 12.0f * Amber_Parse_Float(values[j]);
             }
+            has_lj_pair_A = true;
         }
         else if (current_flag == "LENNARD_JONES_BCOEF")
         {
             int pair_type_numbers =
                 atom_type_numbers * (atom_type_numbers + 1) / 2;
-            Amber_Require_Section_Size(
+            Amber_Require_Exact_Section_Size(
                 values, static_cast<std::size_t>(pair_type_numbers), controller,
-                "Xponge::Amber_Load_Classical_Force_Field");
-            ff->lj.pair_B.resize(pair_type_numbers);
+                "Xponge::Amber_Load_Classical_Force_Field",
+                "LENNARD_JONES_BCOEF");
+            raw_lj_pair_B.resize(pair_type_numbers);
             for (int j = 0; j < pair_type_numbers; j++)
             {
-                ff->lj.pair_B[j] = 6.0f * Amber_Parse_Float(values[j]);
+                raw_lj_pair_B[j] = 6.0f * Amber_Parse_Float(values[j]);
             }
+            has_lj_pair_B = true;
         }
         i--;
+    }
+
+    if (has_lj_pair_A != has_lj_pair_B)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorBadFileFormat,
+            "Xponge::Amber_Load_Classical_Force_Field",
+            "Reason:\n\tLENNARD_JONES_ACOEF and LENNARD_JONES_BCOEF must "
+            "either both be present or both be absent\n");
+    }
+    if (has_hbond_pair_A != has_hbond_pair_B)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorBadFileFormat,
+            "Xponge::Amber_Load_Classical_Force_Field",
+            "Reason:\n\tHBOND_ACOEF and HBOND_BCOEF must either both be "
+            "present or both be absent\n");
+    }
+    if (hbond_type_numbers > 0 && !has_hbond_pair_A)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorBadFileFormat,
+            "Xponge::Amber_Load_Classical_Force_Field",
+            "Reason:\n\tHBOND_ACOEF and HBOND_BCOEF are required when AMBER "
+            "NPHB is greater than zero\n");
+    }
+
+    std::vector<int> canonical_nonbonded_map =
+        Amber_Build_Canonical_Nonbonded_Map(
+            atom_type_numbers, nonbonded_parm_index, has_nonbonded_parm_index,
+            hbond_pair_A, hbond_pair_B, controller,
+            "Xponge::Amber_Load_Classical_Force_Field");
+    if (has_lj_pair_A)
+    {
+        Amber_Remap_LJ_Pair_Matrix(
+            raw_lj_pair_A, raw_lj_pair_B, canonical_nonbonded_map,
+            &ff->lj.pair_A, &ff->lj.pair_B, controller,
+            "Xponge::Amber_Load_Classical_Force_Field", "LENNARD_JONES_ACOEF",
+            "LENNARD_JONES_BCOEF");
     }
 
     ff->lj.atom_type_numbers = atom_type_numbers;

--- a/benchmarks/comparison/tests/amber/tests/comp_amber_nb14.py
+++ b/benchmarks/comparison/tests/amber/tests/comp_amber_nb14.py
@@ -1,0 +1,201 @@
+import math
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+_PERMUTED_TWO_TYPE_NPI = [3, 1, 1, 2]
+
+
+def _flag(name, fmt, values, items_per_line=10):
+    lines = [f"%FLAG {name}", f"%FORMAT({fmt})"]
+    rendered = [str(value) for value in values]
+    for start in range(0, len(rendered), items_per_line):
+        lines.append(" ".join(rendered[start : start + items_per_line]))
+    return "\n".join(lines) + "\n"
+
+
+def _write_prmtop(
+    path,
+    *,
+    atom_types,
+    normal_a,
+    normal_b,
+    nonbonded_parm_index=None,
+    hbond_a=None,
+    hbond_b=None,
+    excluded_counts=None,
+    excluded_list=(),
+):
+    atom_types = list(atom_types)
+    atom_count = len(atom_types)
+    atom_type_count = max(atom_types)
+    if nonbonded_parm_index is None:
+        nonbonded_parm_index = _PERMUTED_TWO_TYPE_NPI
+    if excluded_counts is None:
+        excluded_counts = [0] * atom_count
+    hbond_type_count = max(
+        len(hbond_a) if hbond_a is not None else 0,
+        len(hbond_b) if hbond_b is not None else 0,
+    )
+
+    pointers = [0] * 31
+    pointers[0] = atom_count  # NATOM
+    pointers[1] = atom_type_count  # NTYPES
+    pointers[10] = len(excluded_list)  # NNB
+    pointers[11] = 1  # NRES
+    pointers[19] = hbond_type_count  # NPHB
+    pointers[27] = 1  # IFBOX
+
+    sections = [
+        "%VERSION VERSION_STAMP = V0001.000 DATE = 01/01/70 00:00:00\n",
+        _flag("POINTERS", "10I8", pointers),
+        _flag("CHARGE", "5E16.8", [0.0] * atom_count, 5),
+        _flag("MASS", "5E16.8", [12.0] * atom_count, 5),
+        _flag("ATOM_TYPE_INDEX", "10I8", atom_types),
+        _flag(
+            "NONBONDED_PARM_INDEX",
+            "10I8",
+            nonbonded_parm_index,
+        ),
+        _flag("NUMBER_EXCLUDED_ATOMS", "10I8", excluded_counts),
+        _flag("RESIDUE_POINTER", "10I8", [1]),
+    ]
+    if hbond_a is not None:
+        sections.append(_flag("HBOND_ACOEF", "5E16.8", hbond_a, 5))
+    if hbond_b is not None:
+        sections.append(_flag("HBOND_BCOEF", "5E16.8", hbond_b, 5))
+    sections.extend(
+        [
+            _flag("LENNARD_JONES_ACOEF", "3E24.16", normal_a, 3),
+            _flag("LENNARD_JONES_BCOEF", "3E24.16", normal_b, 3),
+            _flag("EXCLUDED_ATOMS_LIST", "10I8", excluded_list),
+        ]
+    )
+    path.write_text("".join(sections))
+
+
+def _write_rst7(path, coordinates):
+    flat_coordinates = [
+        value for coordinate in coordinates for value in coordinate
+    ]
+    coordinate_lines = []
+    for start in range(0, len(flat_coordinates), 6):
+        coordinate_lines.append(
+            "".join(
+                f"{value:12.7f}"
+                for value in flat_coordinates[start : start + 6]
+            )
+        )
+    path.write_text(
+        "\n".join(
+            [
+                "synthetic AMBER NONBONDED_PARM_INDEX test",
+                f"{len(coordinates):6d}",
+                *coordinate_lines,
+                "  50.0000000  50.0000000  50.0000000",
+                "  90.0000000  90.0000000  90.0000000",
+            ]
+        )
+        + "\n"
+    )
+
+
+def _write_mdin(path, prmtop_path, rst7_path, mdout_path):
+    path.write_text(
+        textwrap.dedent(
+            f"""
+            md_name = "synthetic_amber_nb14"
+            mode = "nve"
+            step_limit = 0
+            dt = 0
+            cutoff = 8.0
+            amber_parm7 = {str(prmtop_path)!r}
+            amber_rst7 = {str(rst7_path)!r}
+            mdout = {str(mdout_path)!r}
+            print_zeroth_frame = 1
+            write_mdout_interval = 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+
+def _run_sponge(tmp_path, coordinates, **prmtop_options):
+    prmtop_path = tmp_path / "synthetic.prmtop"
+    rst7_path = tmp_path / "synthetic.rst7"
+    mdin_path = tmp_path / "mdin.spg.toml"
+    mdout_path = tmp_path / "mdout.txt"
+    _write_prmtop(prmtop_path, **prmtop_options)
+    _write_rst7(rst7_path, coordinates)
+    _write_mdin(mdin_path, prmtop_path, rst7_path, mdout_path)
+    result = subprocess.run(
+        [os.environ.get("SPONGE_BIN", "SPONGE"), "-mdin", str(mdin_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    return result, mdout_path
+
+
+def _extract_mdout_term(mdout_path, term_name):
+    lines = Path(mdout_path).read_text().splitlines()
+    headers = lines[0].split()
+    values = lines[1].split()
+    assert len(headers) == len(values)
+    return float(dict(zip(headers, values))[term_name])
+
+
+def test_nonbonded_parm_index_remaps_ordinary_lj_matrix(tmp_path):
+    result, mdout_path = _run_sponge(
+        tmp_path,
+        [(0.0, 0.0, 0.0), (math.sqrt(3.0), 0.0, 0.0)],
+        atom_types=[1, 2],
+        # The cross term is source entry 1, not canonical array slot 2.
+        normal_a=[729.0, 200.0, 300.0],
+        normal_b=[54.0, 20.0, 30.0],
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode == 0, output
+    assert math.isclose(
+        _extract_mdout_term(mdout_path, "LJ_short"), -1.0, abs_tol=0.01
+    )
+
+
+def test_zero_hbond_placeholder_maps_to_zero_lj(tmp_path):
+    result, mdout_path = _run_sponge(
+        tmp_path,
+        [(0.0, 0.0, 0.0), (math.sqrt(3.0), 0.0, 0.0)],
+        atom_types=[1, 2],
+        normal_a=[729.0, 200.0, 300.0],
+        normal_b=[54.0, 20.0, 30.0],
+        nonbonded_parm_index=[3, -1, -1, 2],
+        hbond_a=[0.0],
+        hbond_b=[0.0],
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode == 0, output
+    assert math.isclose(
+        _extract_mdout_term(mdout_path, "LJ_short"), 0.0, abs_tol=0.01
+    )
+
+
+def test_nonzero_hbond_term_fails_closed(tmp_path):
+    result, _mdout_path = _run_sponge(
+        tmp_path,
+        [(0.0, 0.0, 0.0), (math.sqrt(3.0), 0.0, 0.0)],
+        atom_types=[1, 2],
+        normal_a=[729.0, 200.0, 300.0],
+        normal_b=[54.0, 20.0, 30.0],
+        nonbonded_parm_index=[3, -1, -1, 2],
+        hbond_a=[1.0],
+        hbond_b=[0.0],
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode != 0
+    assert "AMBER 10-12 nonbonded terms are not supported" in output


### PR DESCRIPTION
## 问题

AMBER parm7 中的 LENNARD_JONES_ACOEF/BCOEF 是参数存储表。某一对原子类型应该使用表中的哪一项，必须通过 NTYPES × NTYPES 的NONBONDED_PARM_INDEX 查询。

现有加载器忽略了该索引矩阵，直接假设 AMBER 参数表的存储顺序与 SPONGE 内部的规范三角顺序一致。这样一旦 NONBONDED_PARM_INDEX 指向其他槽位，普通 LJ 以及后续使用同一类型表的 1–4 LJ 都会取错参数。

此外，NONBONDED_PARM_INDEX 的负值不能一概视为坏文件。AMBER 使用负索引指向 HBOND_ACOEF/BCOEF 中的 10–12 参数。仓库已有的 189,441 原子 topology 中就存在两个对称的 -1，它们指向一组全零 HBOND 参数，语义是“该类型对没有 LJ 相互作用”。

## 修复方法

AMBER 使用类型对 - NPI - 参数槽位的间接寻址，SPONGE 使用规范三角数组直接寻址。本 PR 在加载边界完成一次确定性转换，之后所有下游计算仍沿用原来的直接索引，不需要在不同力计算路径里分别补丁。

补充了相关测试