### PR TITLE
支持 CHAMBER 独立的 1–4 Lennard-Jones 系数

### DIFF
--- a/SPONGE/xponge/load/amber.hpp
+++ b/SPONGE/xponge/load/amber.hpp
@@ -246,12 +246,16 @@ static void Amber_Load_Classical_Force_Field(System* system,
     std::vector<float> scnb_scale_factor;
     std::vector<float> raw_lj_pair_A;
     std::vector<float> raw_lj_pair_B;
+    std::vector<float> raw_lj14_pair_A;
+    std::vector<float> raw_lj14_pair_B;
     std::vector<float> hbond_pair_A;
     std::vector<float> hbond_pair_B;
     std::vector<int> nonbonded_parm_index;
 
     bool has_lj_pair_A = false;
     bool has_lj_pair_B = false;
+    bool has_lj14_pair_A = false;
+    bool has_lj14_pair_B = false;
     bool has_hbond_pair_A = false;
     bool has_hbond_pair_B = false;
     bool has_nonbonded_parm_index = false;
@@ -589,6 +593,36 @@ static void Amber_Load_Classical_Force_Field(System* system,
             }
             has_lj_pair_B = true;
         }
+        else if (current_flag == "LENNARD_JONES_14_ACOEF")
+        {
+            int pair_type_numbers =
+                atom_type_numbers * (atom_type_numbers + 1) / 2;
+            Amber_Require_Exact_Section_Size(
+                values, static_cast<std::size_t>(pair_type_numbers), controller,
+                "Xponge::Amber_Load_Classical_Force_Field",
+                "LENNARD_JONES_14_ACOEF");
+            raw_lj14_pair_A.resize(pair_type_numbers);
+            for (int j = 0; j < pair_type_numbers; j++)
+            {
+                raw_lj14_pair_A[j] = 12.0f * Amber_Parse_Float(values[j]);
+            }
+            has_lj14_pair_A = true;
+        }
+        else if (current_flag == "LENNARD_JONES_14_BCOEF")
+        {
+            int pair_type_numbers =
+                atom_type_numbers * (atom_type_numbers + 1) / 2;
+            Amber_Require_Exact_Section_Size(
+                values, static_cast<std::size_t>(pair_type_numbers), controller,
+                "Xponge::Amber_Load_Classical_Force_Field",
+                "LENNARD_JONES_14_BCOEF");
+            raw_lj14_pair_B.resize(pair_type_numbers);
+            for (int j = 0; j < pair_type_numbers; j++)
+            {
+                raw_lj14_pair_B[j] = 6.0f * Amber_Parse_Float(values[j]);
+            }
+            has_lj14_pair_B = true;
+        }
         i--;
     }
 
@@ -599,6 +633,15 @@ static void Amber_Load_Classical_Force_Field(System* system,
             "Xponge::Amber_Load_Classical_Force_Field",
             "Reason:\n\tLENNARD_JONES_ACOEF and LENNARD_JONES_BCOEF must "
             "either both be present or both be absent\n");
+    }
+    if (has_lj14_pair_A != has_lj14_pair_B)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorBadFileFormat,
+            "Xponge::Amber_Load_Classical_Force_Field",
+            "Reason:\n\tLENNARD_JONES_14_ACOEF and "
+            "LENNARD_JONES_14_BCOEF must either both be present or both be "
+            "absent\n");
     }
     if (has_hbond_pair_A != has_hbond_pair_B)
     {
@@ -631,7 +674,23 @@ static void Amber_Load_Classical_Force_Field(System* system,
             "LENNARD_JONES_BCOEF");
     }
 
+    std::vector<float> lj14_pair_A;
+    std::vector<float> lj14_pair_B;
+    if (has_lj14_pair_A)
+    {
+        Amber_Remap_LJ_Pair_Matrix(
+            raw_lj14_pair_A, raw_lj14_pair_B, canonical_nonbonded_map,
+            &lj14_pair_A, &lj14_pair_B, controller,
+            "Xponge::Amber_Load_Classical_Force_Field",
+            "LENNARD_JONES_14_ACOEF", "LENNARD_JONES_14_BCOEF");
+    }
+
     ff->lj.atom_type_numbers = atom_type_numbers;
+
+    const std::vector<float>& nb14_pair_A =
+        has_lj14_pair_A ? lj14_pair_A : ff->lj.pair_A;
+    const std::vector<float>& nb14_pair_B =
+        has_lj14_pair_B ? lj14_pair_B : ff->lj.pair_B;
 
     ff->dihedrals.atom_a.reserve(raw_dihedral_a.size());
     ff->dihedrals.atom_b.reserve(raw_dihedral_a.size());
@@ -685,7 +744,7 @@ static void Amber_Load_Classical_Force_Field(System* system,
         ff->dihedrals.gams.push_back(gams);
 
         if (raw_dihedral_c[i] > 0 && !ff->lj.atom_type.empty() &&
-            !ff->lj.pair_A.empty() && !ff->lj.pair_B.empty())
+            !nb14_pair_A.empty() && !nb14_pair_B.empty())
         {
             int type_a = ff->lj.atom_type[atom_a];
             int type_b = ff->lj.atom_type[atom_d];
@@ -710,8 +769,8 @@ static void Amber_Load_Classical_Force_Field(System* system,
             }
             ff->nb14.atom_a.push_back(atom_a);
             ff->nb14.atom_b.push_back(atom_d);
-            ff->nb14.A.push_back(lj_scale * ff->lj.pair_A[pair_type]);
-            ff->nb14.B.push_back(lj_scale * ff->lj.pair_B[pair_type]);
+            ff->nb14.A.push_back(lj_scale * nb14_pair_A[pair_type]);
+            ff->nb14.B.push_back(lj_scale * nb14_pair_B[pair_type]);
             ff->nb14.cf_scale_factor.push_back(cf_scale);
         }
     }

--- a/benchmarks/comparison/tests/amber/tests/comp_amber_nb14.py
+++ b/benchmarks/comparison/tests/amber/tests/comp_amber_nb14.py
@@ -26,6 +26,9 @@ def _write_prmtop(
     hbond_b=None,
     excluded_counts=None,
     excluded_list=(),
+    dihedral_rows=(),
+    lj14_a=None,
+    lj14_b=None,
 ):
     atom_types = list(atom_types)
     atom_count = len(atom_types)
@@ -42,8 +45,11 @@ def _write_prmtop(
     pointers = [0] * 31
     pointers[0] = atom_count  # NATOM
     pointers[1] = atom_type_count  # NTYPES
+    pointers[7] = len(dihedral_rows)  # MPHIA
     pointers[10] = len(excluded_list)  # NNB
     pointers[11] = 1  # NRES
+    pointers[14] = len(dihedral_rows)  # NPHIA
+    pointers[17] = 1 if dihedral_rows else 0  # NPTRA
     pointers[19] = hbond_type_count  # NPHB
     pointers[27] = 1  # IFBOX
 
@@ -65,13 +71,35 @@ def _write_prmtop(
         sections.append(_flag("HBOND_ACOEF", "5E16.8", hbond_a, 5))
     if hbond_b is not None:
         sections.append(_flag("HBOND_BCOEF", "5E16.8", hbond_b, 5))
+    if dihedral_rows:
+        sections.extend(
+            [
+                _flag("DIHEDRAL_FORCE_CONSTANT", "5E16.8", [0.0], 5),
+                _flag("DIHEDRAL_PERIODICITY", "5E16.8", [1.0], 5),
+                _flag("DIHEDRAL_PHASE", "5E16.8", [0.0], 5),
+                _flag("SCEE_SCALE_FACTOR", "5E16.8", [1.0], 5),
+                _flag("SCNB_SCALE_FACTOR", "5E16.8", [2.0], 5),
+            ]
+        )
     sections.extend(
         [
             _flag("LENNARD_JONES_ACOEF", "3E24.16", normal_a, 3),
             _flag("LENNARD_JONES_BCOEF", "3E24.16", normal_b, 3),
-            _flag("EXCLUDED_ATOMS_LIST", "10I8", excluded_list),
         ]
     )
+    if lj14_a is not None:
+        sections.append(_flag("LENNARD_JONES_14_ACOEF", "3E24.16", lj14_a, 3))
+    if lj14_b is not None:
+        sections.append(_flag("LENNARD_JONES_14_BCOEF", "3E24.16", lj14_b, 3))
+    if dihedral_rows:
+        sections.append(
+            _flag(
+                "DIHEDRALS_WITHOUT_HYDROGEN",
+                "10I8",
+                [value for row in dihedral_rows for value in row],
+            )
+        )
+    sections.append(_flag("EXCLUDED_ATOMS_LIST", "10I8", excluded_list))
     path.write_text("".join(sections))
 
 
@@ -199,3 +227,74 @@ def test_nonzero_hbond_term_fails_closed(tmp_path):
 
     assert result.returncode != 0
     assert "AMBER 10-12 nonbonded terms are not supported" in output
+
+
+_FOUR_ATOM_COORDINATES = [
+    (0.0, 1.0, 0.0),
+    (0.0, 0.0, 0.0),
+    (1.0, 0.0, 0.0),
+    (1.0, 0.0, 1.0),
+]
+
+
+def _four_atom_nb14_options(**overrides):
+    options = {
+        "atom_types": [1, 1, 2, 2],
+        "normal_a": [729.0, 200.0, 300.0],
+        "normal_b": [27.0, 20.0, 30.0],
+        "lj14_a": [729.0, 400.0, 500.0],
+        "lj14_b": [54.0, 40.0, 50.0],
+        "dihedral_rows": [(0, 3, 6, 9, 1)],
+        "excluded_counts": [3, 2, 1, 0],
+        "excluded_list": [2, 3, 4, 3, 4, 4],
+    }
+    options.update(overrides)
+    return options
+
+
+def test_chamber_lj14_matrix_uses_nonbonded_parm_index(tmp_path):
+    result, mdout_path = _run_sponge(
+        tmp_path,
+        _FOUR_ATOM_COORDINATES,
+        **_four_atom_nb14_options(),
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode == 0, output
+    assert "non-bond 14 numbers is 1" in output
+    assert math.isclose(
+        _extract_mdout_term(mdout_path, "nb14_LJ"), -0.5, abs_tol=0.01
+    )
+
+
+def test_missing_chamber_lj14_matrix_falls_back_to_ordinary_lj(tmp_path):
+    result, mdout_path = _run_sponge(
+        tmp_path,
+        _FOUR_ATOM_COORDINATES,
+        **_four_atom_nb14_options(
+            normal_b=[54.0, 20.0, 30.0],
+            lj14_a=None,
+            lj14_b=None,
+        ),
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode == 0, output
+    assert math.isclose(
+        _extract_mdout_term(mdout_path, "nb14_LJ"), -0.5, abs_tol=0.01
+    )
+
+
+def test_chamber_lj14_coefficients_must_be_complete(tmp_path):
+    result, _mdout_path = _run_sponge(
+        tmp_path,
+        _FOUR_ATOM_COORDINATES,
+        **_four_atom_nb14_options(lj14_b=None),
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode != 0
+    assert (
+        "LENNARD_JONES_14_ACOEF and LENNARD_JONES_14_BCOEF must either both "
+        "be present or both be absent"
+    ) in output


### PR DESCRIPTION
## 问题

CHAMBER topology 可以同时提供普通非键参数 `LENNARD_JONES_ACOEF/BCOEF` 和专用于 1–4 相互作用的 `LENNARD_JONES_14_ACOEF/BCOEF`。

专用 1–4 参数可能与普通 LJ 参数不同，不能总由普通参数和 SCNB_SCALE_FACTOR 推导。

现有加载器完全忽略 LENNARD_JONES_14_*，构造二面角端点的 nb14 时始终使用普通 LJ 表。因此，只要 CHAMBER topology 的专用 1–4 参数与普通参数不同，nb14_LJ 就会错误。

## 修复

本 PR 将普通 pair 和 1–4 pair 的参数来源明确分开。两张表都先经过同一个 NPI remapper，因此既不会选错表，也不会在表内取错槽位。

一并补充了相关测试。