### PR TITLE
修复 GROMACS harmonic improper 力常数的 1/2 系数换算

### DIFF
--- a/SPONGE/xponge/load/gromacs.hpp
+++ b/SPONGE/xponge/load/gromacs.hpp
@@ -1530,7 +1530,9 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                     impropers.atom_b.push_back(local_to_global[aj_local]);
                     impropers.atom_c.push_back(local_to_global[ak_local]);
                     impropers.atom_d.push_back(local_to_global[al_local]);
-                    impropers.pk.push_back(Gromacs_To_Kcal(k_kj));
+                    // GROMACS uses E = 1/2*k*(phi-phi0)^2, while SPONGE
+                    // stores the coefficient of (phi-phi0)^2 directly.
+                    impropers.pk.push_back(Gromacs_To_Kcal(k_kj) / 2.0f);
                     impropers.pn.push_back(0.0f);
                     impropers.ipn.push_back(0);
                     impropers.gamc.push_back(Gromacs_To_Radian(phase_deg));

--- a/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_features.py
+++ b/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_features.py
@@ -1,8 +1,11 @@
 import json
+import math
 import os
 import subprocess
 import textwrap
 from pathlib import Path
+
+import pytest
 
 
 def _toml_string(value):
@@ -15,6 +18,17 @@ def _gro_atom(resid, resname, atomname, atomnr, xyz):
         f"{resid:5d}{resname:<5}{atomname:>5}{atomnr:5d}"
         f"{x:8.3f}{y:8.3f}{z:8.3f}"
     )
+
+
+def _extract_mdout_term(mdout_path, term):
+    lines = mdout_path.read_text().splitlines()
+    headers = lines[0].split()
+    values = next(
+        line.split()
+        for line in reversed(lines[1:])
+        if line.strip() and line.lstrip()[0].isdigit()
+    )
+    return float(dict(zip(headers, values))[term])
 
 
 def test_direct_gromacs_topgro_accepts_settles_constraints_and_cmap(tmp_path):
@@ -132,3 +146,112 @@ def test_direct_gromacs_topgro_accepts_settles_constraints_and_cmap(tmp_path):
     assert "constrain pair number is 4" in output
     assert "rigid triangle numbers is 1" in output
     assert "rigid pair numbers is 1" in output
+
+
+def test_direct_gromacs_harmonic_improper_uses_half_force_constant(tmp_path):
+    top_path = tmp_path / "topol.top"
+    gro_path = tmp_path / "conf.gro"
+    mdin_path = tmp_path / "mdin.spg.toml"
+    mdout_path = tmp_path / "mdout.txt"
+
+    top_path.write_text(
+        textwrap.dedent(
+            """
+            [ defaults ]
+            1 2 yes 1.0 1.0
+
+            [ atomtypes ]
+            A A 12.0 0.0 A 0.0 0.0
+            B B 12.0 0.0 A 0.0 0.0
+            C C 12.0 0.0 A 0.0 0.0
+            D D 12.0 0.0 A 0.0 0.0
+
+            [ dihedraltypes ]
+            A B C D 2 0.0 8.368
+
+            [ moleculetype ]
+            IMPLICIT 0
+
+            [ atoms ]
+            1 A 1 IMP A 1 0.0 12.0
+            2 B 1 IMP B 2 0.0 12.0
+            3 C 1 IMP C 3 0.0 12.0
+            4 D 1 IMP D 4 0.0 12.0
+
+            [ dihedrals ]
+            1 2 3 4 2
+
+            [ moleculetype ]
+            EXPLICIT 0
+
+            [ atoms ]
+            1 A 1 EXP A 1 0.0 12.0
+            2 B 1 EXP B 2 0.0 12.0
+            3 C 1 EXP C 3 0.0 12.0
+            4 D 1 EXP D 4 0.0 12.0
+
+            [ dihedrals ]
+            1 2 3 4 2 0.0 8.368
+
+            [ system ]
+            harmonic improper convention
+
+            [ molecules ]
+            IMPLICIT 1
+            EXPLICIT 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+    gro_lines = [
+        "harmonic improper convention",
+        "8",
+        _gro_atom(1, "IMP", "A", 1, (0.000, 0.100, 0.000)),
+        _gro_atom(1, "IMP", "B", 2, (0.000, 0.000, 0.000)),
+        _gro_atom(1, "IMP", "C", 3, (0.100, 0.000, 0.000)),
+        _gro_atom(1, "IMP", "D", 4, (0.100, 0.000, 0.100)),
+        _gro_atom(2, "EXP", "A", 5, (1.000, 0.100, 0.000)),
+        _gro_atom(2, "EXP", "B", 6, (1.000, 0.000, 0.000)),
+        _gro_atom(2, "EXP", "C", 7, (1.100, 0.000, 0.000)),
+        _gro_atom(2, "EXP", "D", 8, (1.100, 0.000, 0.100)),
+        "   5.00000   5.00000   5.00000",
+    ]
+    gro_path.write_text("\n".join(gro_lines) + "\n")
+
+    mdin_path.write_text(
+        textwrap.dedent(
+            f"""
+            md_name = "direct_gromacs_harmonic_improper"
+            mode = "nve"
+            step_limit = 0
+            dt = 0
+            cutoff = 8.0
+            gromacs_top = {_toml_string(top_path)}
+            gromacs_gro = {_toml_string(gro_path)}
+            mdout = {_toml_string(mdout_path)}
+            print_zeroth_frame = 1
+            write_mdout_interval = 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+    result = subprocess.run(
+        [os.environ.get("SPONGE_BIN", "SPONGE"), "-mdin", str(mdin_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stdout + "\n" + result.stderr
+    assert "dihedral_numbers is 2" in result.stdout + result.stderr
+
+    # k=8.368 kJ/mol/rad^2 is 2 kcal/mol/rad^2. Both impropers have
+    # phi=pi/2 and each contributes 1/2*k*phi^2.
+    expected = 2.0 * 0.5 * (8.368 / 4.184) * (math.pi / 2.0) ** 2
+    assert _extract_mdout_term(
+        mdout_path, "improper_dihedral"
+    ) == pytest.approx(expected, abs=0.02)


### PR DESCRIPTION
## 问题

GROMACS 的 harmonic improper，即 `[ dihedrals ]` 中 `funct = 2`，使用：

$$E_{\mathrm{gmx}} = \frac{1}{2} k \, (\varphi - \varphi_0)^2$$

SPONGE 的 improper kernel 则将 `pk` 直接作为二次项系数：

$$E_{\mathrm{sponge}} = pk \times (\varphi - \varphi_0)^2$$

原实现只进行了 kJ/mol 到 kcal/mol 的单位换算：

$$pk = k / 4.184$$

遗漏了 GROMACS 势能定义中的 $\frac{1}{2}$，因此每个 harmonic improper 的能量和势能导数都会扩大一倍。

## 修复

将 harmonic improper 的系数转换改为：

$$pk = k / 4.184 / 2$$