### PR TITLE
修复 GROMACS [nonbond_params] 非键参数覆盖

### DIFF
--- a/SPONGE/xponge/load/gromacs.hpp
+++ b/SPONGE/xponge/load/gromacs.hpp
@@ -180,6 +180,7 @@ struct Gromacs_Topology
     std::vector<Gromacs_Angle_Type> angle_types;
     std::vector<Gromacs_Dihedral_Type> dihedral_types;
     std::vector<Gromacs_Pair_Type> pair_types;
+    std::vector<Gromacs_Pair_Type> nonbond_parameters;
     std::vector<Gromacs_CMap_Type> cmap_types;
     std::unordered_map<std::string, Gromacs_Molecule> molecules;
     std::vector<std::pair<std::string, int>> system_molecules;
@@ -487,10 +488,14 @@ static std::pair<float, float> Gromacs_Get_C6_C12_From_Pair_Parameters(
         return {parameters[0] * 1000000.0f / 4.184f,
                 parameters[1] * 1000000000000.0f / 4.184f};
     }
-    float sigma = Gromacs_To_Angstrom(parameters[0]);
+    float sigma = Gromacs_To_Angstrom(std::fabs(parameters[0]));
     float epsilon = Gromacs_To_Kcal(parameters[1]);
     float sigma6 = std::pow(sigma, 6.0f);
-    return {4.0f * epsilon * sigma6, 4.0f * epsilon * sigma6 * sigma6};
+    float c12 = 4.0f * epsilon * sigma6 * sigma6;
+    // GROMACS uses a negative sigma to request a purely repulsive
+    // interaction: C6 is zero while C12 is calculated from |sigma|.
+    float c6 = parameters[0] < 0.0f ? 0.0f : 4.0f * epsilon * sigma6;
+    return {c6, c12};
 }
 
 static bool Gromacs_Type_Match(const std::string& pattern,
@@ -594,19 +599,33 @@ static const Gromacs_Pair_Type* Gromacs_Find_Pair_Type(
     const std::vector<Gromacs_Pair_Type>& pair_types, const std::string& ai,
     const std::string& aj, int funct)
 {
-    for (const Gromacs_Pair_Type& type : pair_types)
+    for (auto iter = pair_types.rbegin(); iter != pair_types.rend(); ++iter)
     {
-        if (type.funct != funct)
+        if (iter->funct != funct)
         {
             continue;
         }
-        if ((type.ai == ai && type.aj == aj) ||
-            (type.ai == aj && type.aj == ai))
+        if ((iter->ai == ai && iter->aj == aj) ||
+            (iter->ai == aj && iter->aj == ai))
         {
-            return &type;
+            return &*iter;
         }
     }
     return NULL;
+}
+
+static std::pair<float, float> Gromacs_Get_Resolved_Nonbond_C6_C12(
+    const Gromacs_Topology& topology, const Gromacs_Atom_Type& atom_i,
+    const Gromacs_Atom_Type& atom_j)
+{
+    const Gromacs_Pair_Type* parameter = Gromacs_Find_Pair_Type(
+        topology.nonbond_parameters, atom_i.name, atom_j.name, 1);
+    if (parameter != NULL)
+    {
+        return Gromacs_Get_C6_C12_From_Pair_Parameters(topology.defaults,
+                                                       parameter->parameters);
+    }
+    return Gromacs_Get_C6_C12(topology.defaults, atom_i, atom_j);
 }
 
 static int Gromacs_Find_CMap_Type(
@@ -814,6 +833,56 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
                 pair_type.parameters.push_back(std::stof(tokens[i]));
             }
             topology.pair_types.push_back(pair_type);
+        }
+        else if (current_section == "nonbond_params")
+        {
+            if (tokens.size() != 5)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tinvalid [ nonbond_params ] entry: expected "
+                    "exactly five fields\n");
+            }
+
+            Gromacs_Pair_Type parameter;
+            parameter.ai = tokens[0];
+            parameter.aj = tokens[1];
+            bool valid_parameters = true;
+            try
+            {
+                std::size_t parsed_characters = 0;
+                parameter.funct = std::stoi(tokens[2], &parsed_characters);
+                valid_parameters = parsed_characters == tokens[2].size();
+
+                for (std::size_t i = 3; i < tokens.size(); i++)
+                {
+                    parsed_characters = 0;
+                    float value = std::stof(tokens[i], &parsed_characters);
+                    valid_parameters = valid_parameters &&
+                                       parsed_characters == tokens[i].size();
+                    parameter.parameters.push_back(value);
+                }
+            }
+            catch (const std::exception&)
+            {
+                valid_parameters = false;
+            }
+            if (!valid_parameters)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tinvalid numeric field in GROMACS "
+                    "[ nonbond_params ] entry\n");
+            }
+            if (parameter.funct != 1)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tunsupported function in GROMACS "
+                    "[ nonbond_params ]; only Lennard-Jones function 1 is "
+                    "supported\n");
+            }
+            topology.nonbond_parameters.push_back(parameter);
         }
         else if (current_section == "cmaptypes")
         {
@@ -1041,6 +1110,21 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
         }
     }
 
+    for (const Gromacs_Pair_Type& parameter : topology.nonbond_parameters)
+    {
+        for (const std::string& atom_type : {parameter.ai, parameter.aj})
+        {
+            if (topology.atom_types.count(atom_type) == 0)
+            {
+                std::string reason =
+                    "Reason:\n\tundefined GROMACS atom type '" + atom_type +
+                    "' in [ nonbond_params ]\n";
+                controller->Throw_SPONGE_Error(spongeErrorBadFileFormat,
+                                               error_by, reason.c_str());
+            }
+        }
+    }
+
     return topology;
 }
 
@@ -1220,15 +1304,23 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
 
     std::unordered_map<std::string, int> atom_type_id;
     std::vector<std::string> ordered_types;
+    bool preserve_named_atom_types = !topology.nonbond_parameters.empty();
     for (const std::string& atom_type_name : global_atom_types)
     {
-        const Gromacs_Atom_Type& atom_type =
-            topology.atom_types.at(atom_type_name);
-        std::pair<float, float> self_c6_c12 =
-            Gromacs_Get_C6_C12(topology.defaults, atom_type, atom_type);
-        char lj_key[CHAR_LENGTH_MAX];
-        snprintf(lj_key, sizeof(lj_key), "%.9g|%.9g", self_c6_c12.first,
-                 self_c6_c12.second);
+        std::string lj_key = atom_type_name;
+        // Atom type names are part of the interaction identity when an
+        // explicit cross-type override is present.
+        if (!preserve_named_atom_types)
+        {
+            const Gromacs_Atom_Type& atom_type =
+                topology.atom_types.at(atom_type_name);
+            std::pair<float, float> self_c6_c12 =
+                Gromacs_Get_C6_C12(topology.defaults, atom_type, atom_type);
+            char parameter_key[CHAR_LENGTH_MAX];
+            snprintf(parameter_key, sizeof(parameter_key), "%.9g|%.9g",
+                     self_c6_c12.first, self_c6_c12.second);
+            lj_key = parameter_key;
+        }
         auto iter = atom_type_id.find(lj_key);
         if (iter == atom_type_id.end())
         {
@@ -1257,7 +1349,7 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
             const Gromacs_Atom_Type& type_j =
                 topology.atom_types.at(ordered_types[type_j_index]);
             std::pair<float, float> c6_c12 =
-                Gromacs_Get_C6_C12(topology.defaults, type_i, type_j);
+                Gromacs_Get_Resolved_Nonbond_C6_C12(topology, type_i, type_j);
             int pair_id = type_j_index * (type_j_index + 1) / 2 + type_i_index;
             system->classical_force_field.lj.pair_A[pair_id] =
                 12.0f * c6_c12.second;
@@ -1608,9 +1700,8 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                     }
                     else if (topology.defaults.gen_pairs)
                     {
-                        c6_c12 = Gromacs_Get_C6_C12(
-                            topology.defaults,
-                            topology.atom_types.at(atom_i.type),
+                        c6_c12 = Gromacs_Get_Resolved_Nonbond_C6_C12(
+                            topology, topology.atom_types.at(atom_i.type),
                             topology.atom_types.at(atom_j.type));
                         c6_c12.first *= topology.defaults.fudge_lj;
                         c6_c12.second *= topology.defaults.fudge_lj;

--- a/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_nonbond_params.py
+++ b/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_nonbond_params.py
@@ -1,0 +1,316 @@
+import json
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def _toml_string(value):
+    return json.dumps(os.fspath(value))
+
+
+def _gro_atom(resid, resname, atomname, atomnr, x):
+    return (
+        f"{resid:5d}{resname:<5}{atomname:>5}{atomnr:5d}"
+        f"{x:8.3f}{0.0:8.3f}{0.0:8.3f}"
+    )
+
+
+def _run_two_atom_topology(
+    tmp_path, topology, *, distance_nm=0.5, atom_names=("A", "B")
+):
+    top_path = tmp_path / "topol.top"
+    gro_path = tmp_path / "conf.gro"
+    mdin_path = tmp_path / "mdin.spg.toml"
+    mdout_path = tmp_path / "mdout.txt"
+
+    top_path.write_text(textwrap.dedent(topology).strip() + "\n")
+    gro_path.write_text(
+        "\n".join(
+            [
+                "nonbond params test",
+                "2",
+                _gro_atom(1, "PAIR", atom_names[0], 1, 0.0),
+                _gro_atom(1, "PAIR", atom_names[1], 2, distance_nm),
+                "   5.00000   5.00000   5.00000",
+            ]
+        )
+        + "\n"
+    )
+    mdin_path.write_text(
+        textwrap.dedent(
+            f"""
+            md_name = "direct_gromacs_nonbond_params"
+            mode = "nve"
+            step_limit = 0
+            dt = 0
+            cutoff = 8.0
+            gromacs_top = {_toml_string(top_path)}
+            gromacs_gro = {_toml_string(gro_path)}
+            mdout = {_toml_string(mdout_path)}
+            print_zeroth_frame = 1
+            write_mdout_interval = 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+    result = subprocess.run(
+        [os.environ.get("SPONGE_BIN", "SPONGE"), "-mdin", str(mdin_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    return result, mdout_path
+
+
+def _extract_mdout_term(mdout_path, term_name):
+    lines = Path(mdout_path).read_text().splitlines()
+    headers = lines[0].split()
+    values = lines[1].split()
+    assert len(headers) == len(values)
+    return float(dict(zip(headers, values))[term_name])
+
+
+def _lj_energy(sigma_nm, epsilon_kj, distance_nm, scale=1.0):
+    sigma_over_r = abs(sigma_nm) / distance_nm
+    attractive = 0.0 if sigma_nm < 0.0 else sigma_over_r**6
+    return scale * 4.0 * (epsilon_kj / 4.184) * (sigma_over_r**12 - attractive)
+
+
+def test_nonbond_params_override_main_lj_without_fudge_and_keep_named_types(
+    tmp_path,
+):
+    result, mdout_path = _run_two_atom_topology(
+        tmp_path,
+        """
+        [ defaults ]
+        1 2 yes 0.25 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.30 0.4184
+        B B 12.0 0.0 A 0.30 0.4184
+
+        [ nonbond_params ]
+        A B 1 0.25 0.4184
+        B A 1 0.40 4.184
+
+        [ moleculetype ]
+        PAIR 0
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 B 1 PAIR B 2 0.0 12.0
+
+        [ system ]
+        main nonbond override
+
+        [ molecules ]
+        PAIR 1
+        """,
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0, output
+    assert "atom_LJ_type_number is 2" in output
+    assert _extract_mdout_term(mdout_path, "LJ_short") == pytest.approx(
+        _lj_energy(0.40, 4.184, 0.5), abs=0.011
+    )
+
+
+def test_nonbond_params_negative_sigma_is_purely_repulsive(tmp_path):
+    result, mdout_path = _run_two_atom_topology(
+        tmp_path,
+        """
+        [ defaults ]
+        1 2 yes 1.0 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.30 0.4184
+        B B 12.0 0.0 A 0.30 0.4184
+
+        [ nonbond_params ]
+        A B 1 -0.40 4.184
+
+        [ moleculetype ]
+        PAIR 0
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 B 1 PAIR B 2 0.0 12.0
+
+        [ system ]
+        negative sigma override
+
+        [ molecules ]
+        PAIR 1
+        """,
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0, output
+    observed = _extract_mdout_term(mdout_path, "LJ_short")
+    assert observed == pytest.approx(_lj_energy(-0.40, 4.184, 0.5), abs=0.011)
+    assert observed > 0.0
+
+
+def test_nonbond_params_leave_unmatched_type_pair_on_combination_rule(tmp_path):
+    result, mdout_path = _run_two_atom_topology(
+        tmp_path,
+        """
+        [ defaults ]
+        1 2 yes 0.25 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.20 0.4184
+        B B 12.0 0.0 A 0.20 0.4184
+        C C 12.0 0.0 A 0.60 1.6736
+
+        [ nonbond_params ]
+        A B 1 0.10 0.0
+
+        [ moleculetype ]
+        PAIR 0
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 C 1 PAIR C 2 0.0 12.0
+
+        [ system ]
+        unmatched nonbond pair
+
+        [ molecules ]
+        PAIR 1
+        """,
+        atom_names=("A", "C"),
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0, output
+    assert _extract_mdout_term(mdout_path, "LJ_short") == pytest.approx(
+        _lj_energy(0.40, 0.8368, 0.5), abs=0.011
+    )
+
+
+@pytest.mark.parametrize(
+    ("pairtypes", "pair_entry", "sigma_nm", "epsilon_kj", "scale"),
+    [
+        ("", "1 2 1", 0.40, 4.184, 0.25),
+        ("[ pairtypes ]\nA B 1 0.30 8.368", "1 2 1", 0.30, 8.368, 1.0),
+        (
+            "[ pairtypes ]\nA B 1 0.30 8.368",
+            "1 2 1 0.45 4.184",
+            0.45,
+            4.184,
+            1.0,
+        ),
+    ],
+    ids=["generated_override_then_fudge", "pairtypes", "inline"],
+)
+def test_pair_parameter_priority_and_fudge_scope(
+    tmp_path,
+    pairtypes,
+    pair_entry,
+    sigma_nm,
+    epsilon_kj,
+    scale,
+):
+    result, mdout_path = _run_two_atom_topology(
+        tmp_path,
+        f"""
+        [ defaults ]
+        1 2 yes 0.25 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.20 0.4184
+        B B 12.0 0.0 A 0.20 0.4184
+
+        [ nonbond_params ]
+        A B 1 0.40 4.184
+
+        {pairtypes}
+
+        [ moleculetype ]
+        PAIR 1
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 B 1 PAIR B 2 0.0 12.0
+
+        [ bonds ]
+        1 2 1 0.50 0.0
+
+        [ pairs ]
+        {pair_entry}
+
+        [ system ]
+        pair parameter priority
+
+        [ molecules ]
+        PAIR 1
+        """,
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0, output
+    assert _extract_mdout_term(mdout_path, "nb14_LJ") == pytest.approx(
+        _lj_energy(sigma_nm, epsilon_kj, 0.5, scale), abs=0.011
+    )
+
+
+@pytest.mark.parametrize(
+    ("entry", "error_fragment"),
+    [
+        ("A B 1 0.40", "expected exactly five fields"),
+        ("A B 1 0.40 4.184 extra", "expected exactly five fields"),
+        ("A B 2 0.40 4.184", "unsupported function"),
+        ("A B 1 invalid 4.184", "invalid numeric field"),
+        ("A UNKNOWN 1 0.40 4.184", "undefined GROMACS atom type 'UNKNOWN'"),
+    ],
+    ids=[
+        "too_few",
+        "too_many",
+        "unsupported_funct",
+        "invalid_value",
+        "unknown_type",
+    ],
+)
+def test_nonbond_params_reject_malformed_entries(
+    tmp_path, entry, error_fragment
+):
+    result, _ = _run_two_atom_topology(
+        tmp_path,
+        f"""
+        [ defaults ]
+        1 2 yes 0.25 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.30 0.4184
+        B B 12.0 0.0 A 0.30 0.4184
+
+        [ nonbond_params ]
+        {entry}
+
+        [ moleculetype ]
+        PAIR 0
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 B 1 PAIR B 2 0.0 12.0
+
+        [ system ]
+        malformed nonbond override
+
+        [ molecules ]
+        PAIR 1
+        """,
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode != 0
+    assert "spongeErrorBadFileFormat" in output
+    assert error_fragment in output


### PR DESCRIPTION
## 问题

GROMACS topology 可以通过 [ nonbond_params ] 为特定 atom-type 对覆盖默认组合参数。SPONGE 现在的解析器实现没有解析该 section，导致这些参数被静默忽略，程序仍按 [ defaults ] 的 combination rule 生成 LJ 参数。

此外，还有一些相关的问题：

- 原实现会将 self C6/C12 相同的命名 atom type 合并，但显式的跨类型 override 依赖类型名称
- 重复 pair 定义按先定义优先，不符合后定义覆盖前定义的语义
- GROMACS 使用负 sigma 表示纯排斥，原转换经过偶次幂后丢失符号，错误地产生了非零 C6 吸引项

## 修复

- 严格解析 [ nonbond_params ] 的五个字段
- 复用现有 Gromacs_Pair_Type、pair 查找和参数转换逻辑
- 将 A-B 与 B-A 视为同一类型对
- 逆序查找，使最后一个匹配定义生效
- 有显式 override 时保留命名 atom type，不再因 self 参数相同而错误折叠
- 有匹配项时使用 override，无匹配项时回退原 combination rule
- 负 sigma 修复

这个PR内尚仅支持 LJ funct = 1