### PR TITLE
feat: merge Amber and GROMACS parser improvements

### DIFF
--- a/SPONGE/xponge/load/amber.hpp
+++ b/SPONGE/xponge/load/amber.hpp
@@ -39,6 +39,152 @@ static void Amber_Require_Section_Size(const std::vector<std::string>& values,
     }
 }
 
+template <typename T>
+static void Amber_Require_Exact_Section_Size(const std::vector<T>& values,
+                                             std::size_t expected_count,
+                                             CONTROLLER* controller,
+                                             const char* error_by,
+                                             const char* section_name)
+{
+    if (values.size() != expected_count)
+    {
+        controller->Throw_Formatted_SPONGE_Error(
+            spongeErrorBadFileFormat, error_by,
+            "Reason:\n\tAMBER section %s has %zu values; expected %zu\n",
+            section_name, values.size(), expected_count);
+    }
+}
+
+static std::vector<int> Amber_Build_Canonical_Nonbonded_Map(
+    int atom_type_numbers, const std::vector<int>& nonbonded_parm_index,
+    bool has_nonbonded_parm_index, const std::vector<float>& hbond_pair_A,
+    const std::vector<float>& hbond_pair_B, CONTROLLER* controller,
+    const char* error_by)
+{
+    if (atom_type_numbers < 0)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorBadFileFormat, error_by,
+            "Reason:\n\tthe AMBER atom type count cannot be negative\n");
+    }
+
+    std::size_t type_numbers = static_cast<std::size_t>(atom_type_numbers);
+    std::size_t pair_type_numbers = type_numbers * (type_numbers + 1) / 2;
+    std::vector<int> source_index(pair_type_numbers, -1);
+    if (!has_nonbonded_parm_index)
+    {
+        if (atom_type_numbers > 1)
+        {
+            controller->Throw_SPONGE_Error(
+                spongeErrorBadFileFormat, error_by,
+                "Reason:\n\tNONBONDED_PARM_INDEX is required when AMBER "
+                "NTYPES is greater than 1\n");
+        }
+        for (std::size_t i = 0; i < pair_type_numbers; i++)
+        {
+            source_index[i] = static_cast<int>(i);
+        }
+        return source_index;
+    }
+
+    Amber_Require_Exact_Section_Size(nonbonded_parm_index,
+                                     type_numbers * type_numbers, controller,
+                                     error_by, "NONBONDED_PARM_INDEX");
+    for (int high = 0; high < atom_type_numbers; high++)
+    {
+        for (int low = 0; low <= high; low++)
+        {
+            int forward = nonbonded_parm_index[static_cast<std::size_t>(low) *
+                                                   type_numbers +
+                                               high];
+            int reverse = nonbonded_parm_index[static_cast<std::size_t>(high) *
+                                                   type_numbers +
+                                               low];
+            if (forward != reverse)
+            {
+                controller->Throw_Formatted_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tNONBONDED_PARM_INDEX is asymmetric for atom "
+                    "types %d and %d\n",
+                    low + 1, high + 1);
+            }
+            std::size_t canonical_index =
+                static_cast<std::size_t>(high) * (high + 1) / 2 + low;
+            if (forward > 0)
+            {
+                if (static_cast<std::size_t>(forward) > pair_type_numbers)
+                {
+                    controller->Throw_Formatted_SPONGE_Error(
+                        spongeErrorBadFileFormat, error_by,
+                        "Reason:\n\tNONBONDED_PARM_INDEX value %d for atom "
+                        "types %d and %d is outside [1, %zu]\n",
+                        forward, low + 1, high + 1, pair_type_numbers);
+                }
+                source_index[canonical_index] = forward - 1;
+                continue;
+            }
+            if (forward == 0)
+            {
+                controller->Throw_Formatted_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tNONBONDED_PARM_INDEX contains zero for atom "
+                    "types %d and %d\n",
+                    low + 1, high + 1);
+            }
+
+            long long hbond_index_value = -static_cast<long long>(forward) - 1;
+            if (hbond_index_value < 0 ||
+                static_cast<std::size_t>(hbond_index_value) >=
+                    hbond_pair_A.size() ||
+                static_cast<std::size_t>(hbond_index_value) >=
+                    hbond_pair_B.size())
+            {
+                controller->Throw_Formatted_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tNONBONDED_PARM_INDEX value %d for atom types "
+                    "%d and %d does not select a valid HBOND parameter\n",
+                    forward, low + 1, high + 1);
+            }
+            std::size_t hbond_index =
+                static_cast<std::size_t>(hbond_index_value);
+            if (hbond_pair_A[hbond_index] != 0.0f ||
+                hbond_pair_B[hbond_index] != 0.0f)
+            {
+                controller->Throw_Formatted_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tAMBER 10-12 nonbonded terms are not supported; "
+                    "atom types %d and %d select nonzero HBOND parameter %zu\n",
+                    low + 1, high + 1, hbond_index + 1);
+            }
+            source_index[canonical_index] = -1;
+        }
+    }
+    return source_index;
+}
+
+static void Amber_Remap_LJ_Pair_Matrix(
+    const std::vector<float>& raw_pair_A, const std::vector<float>& raw_pair_B,
+    const std::vector<int>& source_index, std::vector<float>* pair_A,
+    std::vector<float>* pair_B, CONTROLLER* controller, const char* error_by,
+    const char* section_A, const char* section_B)
+{
+    Amber_Require_Exact_Section_Size(raw_pair_A, source_index.size(),
+                                     controller, error_by, section_A);
+    Amber_Require_Exact_Section_Size(raw_pair_B, source_index.size(),
+                                     controller, error_by, section_B);
+    pair_A->assign(source_index.size(), 0.0f);
+    pair_B->assign(source_index.size(), 0.0f);
+    for (std::size_t i = 0; i < source_index.size(); i++)
+    {
+        int source = source_index[i];
+        if (source >= 0)
+        {
+            pair_A->at(i) = raw_pair_A.at(static_cast<std::size_t>(source));
+            pair_B->at(i) = raw_pair_B.at(static_cast<std::size_t>(source));
+        }
+    }
+}
+
 static int Amber_Get_Atom_Numbers(const System* system);
 static std::vector<std::string> Amber_Read_Section(
     const std::vector<std::string>& lines, std::size_t* index);
@@ -87,6 +233,7 @@ static void Amber_Load_Classical_Force_Field(System* system,
     int bond_type_numbers = 0;
     int angle_type_numbers = 0;
     int dihedral_type_numbers = 0;
+    int hbond_type_numbers = 0;
 
     std::vector<float> bond_type_k;
     std::vector<float> bond_type_r0;
@@ -97,6 +244,17 @@ static void Amber_Load_Classical_Force_Field(System* system,
     std::vector<float> dihedral_type_periodicity;
     std::vector<float> scee_scale_factor;
     std::vector<float> scnb_scale_factor;
+    std::vector<float> raw_lj_pair_A;
+    std::vector<float> raw_lj_pair_B;
+    std::vector<float> hbond_pair_A;
+    std::vector<float> hbond_pair_B;
+    std::vector<int> nonbonded_parm_index;
+
+    bool has_lj_pair_A = false;
+    bool has_lj_pair_B = false;
+    bool has_hbond_pair_A = false;
+    bool has_hbond_pair_B = false;
+    bool has_nonbonded_parm_index = false;
 
     std::vector<int> raw_dihedral_a;
     std::vector<int> raw_dihedral_b;
@@ -118,7 +276,7 @@ static void Amber_Load_Classical_Force_Field(System* system,
         if (current_flag == "POINTERS")
         {
             Amber_Require_Section_Size(
-                values, 18, controller,
+                values, 20, controller,
                 "Xponge::Amber_Load_Classical_Force_Field");
             atom_numbers = Amber_Parse_Int(values[0]);
             atom_type_numbers = Amber_Parse_Int(values[1]);
@@ -131,6 +289,14 @@ static void Amber_Load_Classical_Force_Field(System* system,
             bond_type_numbers = Amber_Parse_Int(values[15]);
             angle_type_numbers = Amber_Parse_Int(values[16]);
             dihedral_type_numbers = Amber_Parse_Int(values[17]);
+            hbond_type_numbers = Amber_Parse_Int(values[19]);
+            if (hbond_type_numbers < 0)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat,
+                    "Xponge::Amber_Load_Classical_Force_Field",
+                    "Reason:\n\tAMBER NPHB cannot be negative\n");
+            }
         }
         else if (current_flag == "BOND_FORCE_CONSTANT")
         {
@@ -358,33 +524,111 @@ static void Amber_Load_Classical_Force_Field(System* system,
                 ff->lj.atom_type[j] = Amber_Parse_Int(values[j]) - 1;
             }
         }
+        else if (current_flag == "NONBONDED_PARM_INDEX")
+        {
+            nonbonded_parm_index.resize(values.size());
+            for (std::size_t j = 0; j < values.size(); j++)
+            {
+                nonbonded_parm_index[j] = Amber_Parse_Int(values[j]);
+            }
+            has_nonbonded_parm_index = true;
+        }
+        else if (current_flag == "HBOND_ACOEF")
+        {
+            Amber_Require_Exact_Section_Size(
+                values, static_cast<std::size_t>(hbond_type_numbers),
+                controller, "Xponge::Amber_Load_Classical_Force_Field",
+                "HBOND_ACOEF");
+            hbond_pair_A.resize(hbond_type_numbers);
+            for (int j = 0; j < hbond_type_numbers; j++)
+            {
+                hbond_pair_A[j] = Amber_Parse_Float(values[j]);
+            }
+            has_hbond_pair_A = true;
+        }
+        else if (current_flag == "HBOND_BCOEF")
+        {
+            Amber_Require_Exact_Section_Size(
+                values, static_cast<std::size_t>(hbond_type_numbers),
+                controller, "Xponge::Amber_Load_Classical_Force_Field",
+                "HBOND_BCOEF");
+            hbond_pair_B.resize(hbond_type_numbers);
+            for (int j = 0; j < hbond_type_numbers; j++)
+            {
+                hbond_pair_B[j] = Amber_Parse_Float(values[j]);
+            }
+            has_hbond_pair_B = true;
+        }
         else if (current_flag == "LENNARD_JONES_ACOEF")
         {
             int pair_type_numbers =
                 atom_type_numbers * (atom_type_numbers + 1) / 2;
-            Amber_Require_Section_Size(
+            Amber_Require_Exact_Section_Size(
                 values, static_cast<std::size_t>(pair_type_numbers), controller,
-                "Xponge::Amber_Load_Classical_Force_Field");
-            ff->lj.pair_A.resize(pair_type_numbers);
+                "Xponge::Amber_Load_Classical_Force_Field",
+                "LENNARD_JONES_ACOEF");
+            raw_lj_pair_A.resize(pair_type_numbers);
             for (int j = 0; j < pair_type_numbers; j++)
             {
-                ff->lj.pair_A[j] = 12.0f * Amber_Parse_Float(values[j]);
+                raw_lj_pair_A[j] = 12.0f * Amber_Parse_Float(values[j]);
             }
+            has_lj_pair_A = true;
         }
         else if (current_flag == "LENNARD_JONES_BCOEF")
         {
             int pair_type_numbers =
                 atom_type_numbers * (atom_type_numbers + 1) / 2;
-            Amber_Require_Section_Size(
+            Amber_Require_Exact_Section_Size(
                 values, static_cast<std::size_t>(pair_type_numbers), controller,
-                "Xponge::Amber_Load_Classical_Force_Field");
-            ff->lj.pair_B.resize(pair_type_numbers);
+                "Xponge::Amber_Load_Classical_Force_Field",
+                "LENNARD_JONES_BCOEF");
+            raw_lj_pair_B.resize(pair_type_numbers);
             for (int j = 0; j < pair_type_numbers; j++)
             {
-                ff->lj.pair_B[j] = 6.0f * Amber_Parse_Float(values[j]);
+                raw_lj_pair_B[j] = 6.0f * Amber_Parse_Float(values[j]);
             }
+            has_lj_pair_B = true;
         }
         i--;
+    }
+
+    if (has_lj_pair_A != has_lj_pair_B)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorBadFileFormat,
+            "Xponge::Amber_Load_Classical_Force_Field",
+            "Reason:\n\tLENNARD_JONES_ACOEF and LENNARD_JONES_BCOEF must "
+            "either both be present or both be absent\n");
+    }
+    if (has_hbond_pair_A != has_hbond_pair_B)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorBadFileFormat,
+            "Xponge::Amber_Load_Classical_Force_Field",
+            "Reason:\n\tHBOND_ACOEF and HBOND_BCOEF must either both be "
+            "present or both be absent\n");
+    }
+    if (hbond_type_numbers > 0 && !has_hbond_pair_A)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorBadFileFormat,
+            "Xponge::Amber_Load_Classical_Force_Field",
+            "Reason:\n\tHBOND_ACOEF and HBOND_BCOEF are required when AMBER "
+            "NPHB is greater than zero\n");
+    }
+
+    std::vector<int> canonical_nonbonded_map =
+        Amber_Build_Canonical_Nonbonded_Map(
+            atom_type_numbers, nonbonded_parm_index, has_nonbonded_parm_index,
+            hbond_pair_A, hbond_pair_B, controller,
+            "Xponge::Amber_Load_Classical_Force_Field");
+    if (has_lj_pair_A)
+    {
+        Amber_Remap_LJ_Pair_Matrix(
+            raw_lj_pair_A, raw_lj_pair_B, canonical_nonbonded_map,
+            &ff->lj.pair_A, &ff->lj.pair_B, controller,
+            "Xponge::Amber_Load_Classical_Force_Field", "LENNARD_JONES_ACOEF",
+            "LENNARD_JONES_BCOEF");
     }
 
     ff->lj.atom_type_numbers = atom_type_numbers;

--- a/SPONGE/xponge/load/amber.hpp
+++ b/SPONGE/xponge/load/amber.hpp
@@ -246,12 +246,16 @@ static void Amber_Load_Classical_Force_Field(System* system,
     std::vector<float> scnb_scale_factor;
     std::vector<float> raw_lj_pair_A;
     std::vector<float> raw_lj_pair_B;
+    std::vector<float> raw_lj14_pair_A;
+    std::vector<float> raw_lj14_pair_B;
     std::vector<float> hbond_pair_A;
     std::vector<float> hbond_pair_B;
     std::vector<int> nonbonded_parm_index;
 
     bool has_lj_pair_A = false;
     bool has_lj_pair_B = false;
+    bool has_lj14_pair_A = false;
+    bool has_lj14_pair_B = false;
     bool has_hbond_pair_A = false;
     bool has_hbond_pair_B = false;
     bool has_nonbonded_parm_index = false;
@@ -589,6 +593,36 @@ static void Amber_Load_Classical_Force_Field(System* system,
             }
             has_lj_pair_B = true;
         }
+        else if (current_flag == "LENNARD_JONES_14_ACOEF")
+        {
+            int pair_type_numbers =
+                atom_type_numbers * (atom_type_numbers + 1) / 2;
+            Amber_Require_Exact_Section_Size(
+                values, static_cast<std::size_t>(pair_type_numbers), controller,
+                "Xponge::Amber_Load_Classical_Force_Field",
+                "LENNARD_JONES_14_ACOEF");
+            raw_lj14_pair_A.resize(pair_type_numbers);
+            for (int j = 0; j < pair_type_numbers; j++)
+            {
+                raw_lj14_pair_A[j] = 12.0f * Amber_Parse_Float(values[j]);
+            }
+            has_lj14_pair_A = true;
+        }
+        else if (current_flag == "LENNARD_JONES_14_BCOEF")
+        {
+            int pair_type_numbers =
+                atom_type_numbers * (atom_type_numbers + 1) / 2;
+            Amber_Require_Exact_Section_Size(
+                values, static_cast<std::size_t>(pair_type_numbers), controller,
+                "Xponge::Amber_Load_Classical_Force_Field",
+                "LENNARD_JONES_14_BCOEF");
+            raw_lj14_pair_B.resize(pair_type_numbers);
+            for (int j = 0; j < pair_type_numbers; j++)
+            {
+                raw_lj14_pair_B[j] = 6.0f * Amber_Parse_Float(values[j]);
+            }
+            has_lj14_pair_B = true;
+        }
         i--;
     }
 
@@ -599,6 +633,15 @@ static void Amber_Load_Classical_Force_Field(System* system,
             "Xponge::Amber_Load_Classical_Force_Field",
             "Reason:\n\tLENNARD_JONES_ACOEF and LENNARD_JONES_BCOEF must "
             "either both be present or both be absent\n");
+    }
+    if (has_lj14_pair_A != has_lj14_pair_B)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorBadFileFormat,
+            "Xponge::Amber_Load_Classical_Force_Field",
+            "Reason:\n\tLENNARD_JONES_14_ACOEF and "
+            "LENNARD_JONES_14_BCOEF must either both be present or both be "
+            "absent\n");
     }
     if (has_hbond_pair_A != has_hbond_pair_B)
     {
@@ -631,7 +674,23 @@ static void Amber_Load_Classical_Force_Field(System* system,
             "LENNARD_JONES_BCOEF");
     }
 
+    std::vector<float> lj14_pair_A;
+    std::vector<float> lj14_pair_B;
+    if (has_lj14_pair_A)
+    {
+        Amber_Remap_LJ_Pair_Matrix(
+            raw_lj14_pair_A, raw_lj14_pair_B, canonical_nonbonded_map,
+            &lj14_pair_A, &lj14_pair_B, controller,
+            "Xponge::Amber_Load_Classical_Force_Field",
+            "LENNARD_JONES_14_ACOEF", "LENNARD_JONES_14_BCOEF");
+    }
+
     ff->lj.atom_type_numbers = atom_type_numbers;
+
+    const std::vector<float>& nb14_pair_A =
+        has_lj14_pair_A ? lj14_pair_A : ff->lj.pair_A;
+    const std::vector<float>& nb14_pair_B =
+        has_lj14_pair_B ? lj14_pair_B : ff->lj.pair_B;
 
     ff->dihedrals.atom_a.reserve(raw_dihedral_a.size());
     ff->dihedrals.atom_b.reserve(raw_dihedral_a.size());
@@ -685,7 +744,7 @@ static void Amber_Load_Classical_Force_Field(System* system,
         ff->dihedrals.gams.push_back(gams);
 
         if (raw_dihedral_c[i] > 0 && !ff->lj.atom_type.empty() &&
-            !ff->lj.pair_A.empty() && !ff->lj.pair_B.empty())
+            !nb14_pair_A.empty() && !nb14_pair_B.empty())
         {
             int type_a = ff->lj.atom_type[atom_a];
             int type_b = ff->lj.atom_type[atom_d];
@@ -710,8 +769,8 @@ static void Amber_Load_Classical_Force_Field(System* system,
             }
             ff->nb14.atom_a.push_back(atom_a);
             ff->nb14.atom_b.push_back(atom_d);
-            ff->nb14.A.push_back(lj_scale * ff->lj.pair_A[pair_type]);
-            ff->nb14.B.push_back(lj_scale * ff->lj.pair_B[pair_type]);
+            ff->nb14.A.push_back(lj_scale * nb14_pair_A[pair_type]);
+            ff->nb14.B.push_back(lj_scale * nb14_pair_B[pair_type]);
             ff->nb14.cf_scale_factor.push_back(cf_scale);
         }
     }

--- a/SPONGE/xponge/load/gromacs.hpp
+++ b/SPONGE/xponge/load/gromacs.hpp
@@ -180,6 +180,7 @@ struct Gromacs_Topology
     std::vector<Gromacs_Angle_Type> angle_types;
     std::vector<Gromacs_Dihedral_Type> dihedral_types;
     std::vector<Gromacs_Pair_Type> pair_types;
+    std::vector<Gromacs_Pair_Type> nonbond_parameters;
     std::vector<Gromacs_CMap_Type> cmap_types;
     std::unordered_map<std::string, Gromacs_Molecule> molecules;
     std::vector<std::pair<std::string, int>> system_molecules;
@@ -487,10 +488,14 @@ static std::pair<float, float> Gromacs_Get_C6_C12_From_Pair_Parameters(
         return {parameters[0] * 1000000.0f / 4.184f,
                 parameters[1] * 1000000000000.0f / 4.184f};
     }
-    float sigma = Gromacs_To_Angstrom(parameters[0]);
+    float sigma = Gromacs_To_Angstrom(std::fabs(parameters[0]));
     float epsilon = Gromacs_To_Kcal(parameters[1]);
     float sigma6 = std::pow(sigma, 6.0f);
-    return {4.0f * epsilon * sigma6, 4.0f * epsilon * sigma6 * sigma6};
+    float c12 = 4.0f * epsilon * sigma6 * sigma6;
+    // GROMACS uses a negative sigma to request a purely repulsive
+    // interaction: C6 is zero while C12 is calculated from |sigma|.
+    float c6 = parameters[0] < 0.0f ? 0.0f : 4.0f * epsilon * sigma6;
+    return {c6, c12};
 }
 
 static bool Gromacs_Type_Match(const std::string& pattern,
@@ -594,19 +599,33 @@ static const Gromacs_Pair_Type* Gromacs_Find_Pair_Type(
     const std::vector<Gromacs_Pair_Type>& pair_types, const std::string& ai,
     const std::string& aj, int funct)
 {
-    for (const Gromacs_Pair_Type& type : pair_types)
+    for (auto iter = pair_types.rbegin(); iter != pair_types.rend(); ++iter)
     {
-        if (type.funct != funct)
+        if (iter->funct != funct)
         {
             continue;
         }
-        if ((type.ai == ai && type.aj == aj) ||
-            (type.ai == aj && type.aj == ai))
+        if ((iter->ai == ai && iter->aj == aj) ||
+            (iter->ai == aj && iter->aj == ai))
         {
-            return &type;
+            return &*iter;
         }
     }
     return NULL;
+}
+
+static std::pair<float, float> Gromacs_Get_Resolved_Nonbond_C6_C12(
+    const Gromacs_Topology& topology, const Gromacs_Atom_Type& atom_i,
+    const Gromacs_Atom_Type& atom_j)
+{
+    const Gromacs_Pair_Type* parameter = Gromacs_Find_Pair_Type(
+        topology.nonbond_parameters, atom_i.name, atom_j.name, 1);
+    if (parameter != NULL)
+    {
+        return Gromacs_Get_C6_C12_From_Pair_Parameters(topology.defaults,
+                                                       parameter->parameters);
+    }
+    return Gromacs_Get_C6_C12(topology.defaults, atom_i, atom_j);
 }
 
 static int Gromacs_Find_CMap_Type(
@@ -814,6 +833,56 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
                 pair_type.parameters.push_back(std::stof(tokens[i]));
             }
             topology.pair_types.push_back(pair_type);
+        }
+        else if (current_section == "nonbond_params")
+        {
+            if (tokens.size() != 5)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tinvalid [ nonbond_params ] entry: expected "
+                    "exactly five fields\n");
+            }
+
+            Gromacs_Pair_Type parameter;
+            parameter.ai = tokens[0];
+            parameter.aj = tokens[1];
+            bool valid_parameters = true;
+            try
+            {
+                std::size_t parsed_characters = 0;
+                parameter.funct = std::stoi(tokens[2], &parsed_characters);
+                valid_parameters = parsed_characters == tokens[2].size();
+
+                for (std::size_t i = 3; i < tokens.size(); i++)
+                {
+                    parsed_characters = 0;
+                    float value = std::stof(tokens[i], &parsed_characters);
+                    valid_parameters = valid_parameters &&
+                                       parsed_characters == tokens[i].size();
+                    parameter.parameters.push_back(value);
+                }
+            }
+            catch (const std::exception&)
+            {
+                valid_parameters = false;
+            }
+            if (!valid_parameters)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tinvalid numeric field in GROMACS "
+                    "[ nonbond_params ] entry\n");
+            }
+            if (parameter.funct != 1)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tunsupported function in GROMACS "
+                    "[ nonbond_params ]; only Lennard-Jones function 1 is "
+                    "supported\n");
+            }
+            topology.nonbond_parameters.push_back(parameter);
         }
         else if (current_section == "cmaptypes")
         {
@@ -1041,6 +1110,21 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
         }
     }
 
+    for (const Gromacs_Pair_Type& parameter : topology.nonbond_parameters)
+    {
+        for (const std::string& atom_type : {parameter.ai, parameter.aj})
+        {
+            if (topology.atom_types.count(atom_type) == 0)
+            {
+                std::string reason =
+                    "Reason:\n\tundefined GROMACS atom type '" + atom_type +
+                    "' in [ nonbond_params ]\n";
+                controller->Throw_SPONGE_Error(spongeErrorBadFileFormat,
+                                               error_by, reason.c_str());
+            }
+        }
+    }
+
     return topology;
 }
 
@@ -1220,15 +1304,23 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
 
     std::unordered_map<std::string, int> atom_type_id;
     std::vector<std::string> ordered_types;
+    bool preserve_named_atom_types = !topology.nonbond_parameters.empty();
     for (const std::string& atom_type_name : global_atom_types)
     {
-        const Gromacs_Atom_Type& atom_type =
-            topology.atom_types.at(atom_type_name);
-        std::pair<float, float> self_c6_c12 =
-            Gromacs_Get_C6_C12(topology.defaults, atom_type, atom_type);
-        char lj_key[CHAR_LENGTH_MAX];
-        snprintf(lj_key, sizeof(lj_key), "%.9g|%.9g", self_c6_c12.first,
-                 self_c6_c12.second);
+        std::string lj_key = atom_type_name;
+        // Atom type names are part of the interaction identity when an
+        // explicit cross-type override is present.
+        if (!preserve_named_atom_types)
+        {
+            const Gromacs_Atom_Type& atom_type =
+                topology.atom_types.at(atom_type_name);
+            std::pair<float, float> self_c6_c12 =
+                Gromacs_Get_C6_C12(topology.defaults, atom_type, atom_type);
+            char parameter_key[CHAR_LENGTH_MAX];
+            snprintf(parameter_key, sizeof(parameter_key), "%.9g|%.9g",
+                     self_c6_c12.first, self_c6_c12.second);
+            lj_key = parameter_key;
+        }
         auto iter = atom_type_id.find(lj_key);
         if (iter == atom_type_id.end())
         {
@@ -1257,7 +1349,7 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
             const Gromacs_Atom_Type& type_j =
                 topology.atom_types.at(ordered_types[type_j_index]);
             std::pair<float, float> c6_c12 =
-                Gromacs_Get_C6_C12(topology.defaults, type_i, type_j);
+                Gromacs_Get_Resolved_Nonbond_C6_C12(topology, type_i, type_j);
             int pair_id = type_j_index * (type_j_index + 1) / 2 + type_i_index;
             system->classical_force_field.lj.pair_A[pair_id] =
                 12.0f * c6_c12.second;
@@ -1610,9 +1702,8 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                     }
                     else if (topology.defaults.gen_pairs)
                     {
-                        c6_c12 = Gromacs_Get_C6_C12(
-                            topology.defaults,
-                            topology.atom_types.at(atom_i.type),
+                        c6_c12 = Gromacs_Get_Resolved_Nonbond_C6_C12(
+                            topology, topology.atom_types.at(atom_i.type),
                             topology.atom_types.at(atom_j.type));
                         c6_c12.first *= topology.defaults.fudge_lj;
                         c6_c12.second *= topology.defaults.fudge_lj;

--- a/SPONGE/xponge/load/gromacs.hpp
+++ b/SPONGE/xponge/load/gromacs.hpp
@@ -1530,7 +1530,9 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                     impropers.atom_b.push_back(local_to_global[aj_local]);
                     impropers.atom_c.push_back(local_to_global[ak_local]);
                     impropers.atom_d.push_back(local_to_global[al_local]);
-                    impropers.pk.push_back(Gromacs_To_Kcal(k_kj));
+                    // GROMACS uses E = 1/2*k*(phi-phi0)^2, while SPONGE
+                    // stores the coefficient of (phi-phi0)^2 directly.
+                    impropers.pk.push_back(Gromacs_To_Kcal(k_kj) / 2.0f);
                     impropers.pn.push_back(0.0f);
                     impropers.ipn.push_back(0);
                     impropers.gamc.push_back(Gromacs_To_Radian(phase_deg));

--- a/benchmarks/comparison/tests/amber/tests/comp_amber_nb14.py
+++ b/benchmarks/comparison/tests/amber/tests/comp_amber_nb14.py
@@ -26,6 +26,9 @@ def _write_prmtop(
     hbond_b=None,
     excluded_counts=None,
     excluded_list=(),
+    dihedral_rows=(),
+    lj14_a=None,
+    lj14_b=None,
 ):
     atom_types = list(atom_types)
     atom_count = len(atom_types)
@@ -42,8 +45,11 @@ def _write_prmtop(
     pointers = [0] * 31
     pointers[0] = atom_count  # NATOM
     pointers[1] = atom_type_count  # NTYPES
+    pointers[7] = len(dihedral_rows)  # MPHIA
     pointers[10] = len(excluded_list)  # NNB
     pointers[11] = 1  # NRES
+    pointers[14] = len(dihedral_rows)  # NPHIA
+    pointers[17] = 1 if dihedral_rows else 0  # NPTRA
     pointers[19] = hbond_type_count  # NPHB
     pointers[27] = 1  # IFBOX
 
@@ -65,13 +71,35 @@ def _write_prmtop(
         sections.append(_flag("HBOND_ACOEF", "5E16.8", hbond_a, 5))
     if hbond_b is not None:
         sections.append(_flag("HBOND_BCOEF", "5E16.8", hbond_b, 5))
+    if dihedral_rows:
+        sections.extend(
+            [
+                _flag("DIHEDRAL_FORCE_CONSTANT", "5E16.8", [0.0], 5),
+                _flag("DIHEDRAL_PERIODICITY", "5E16.8", [1.0], 5),
+                _flag("DIHEDRAL_PHASE", "5E16.8", [0.0], 5),
+                _flag("SCEE_SCALE_FACTOR", "5E16.8", [1.0], 5),
+                _flag("SCNB_SCALE_FACTOR", "5E16.8", [2.0], 5),
+            ]
+        )
     sections.extend(
         [
             _flag("LENNARD_JONES_ACOEF", "3E24.16", normal_a, 3),
             _flag("LENNARD_JONES_BCOEF", "3E24.16", normal_b, 3),
-            _flag("EXCLUDED_ATOMS_LIST", "10I8", excluded_list),
         ]
     )
+    if lj14_a is not None:
+        sections.append(_flag("LENNARD_JONES_14_ACOEF", "3E24.16", lj14_a, 3))
+    if lj14_b is not None:
+        sections.append(_flag("LENNARD_JONES_14_BCOEF", "3E24.16", lj14_b, 3))
+    if dihedral_rows:
+        sections.append(
+            _flag(
+                "DIHEDRALS_WITHOUT_HYDROGEN",
+                "10I8",
+                [value for row in dihedral_rows for value in row],
+            )
+        )
+    sections.append(_flag("EXCLUDED_ATOMS_LIST", "10I8", excluded_list))
     path.write_text("".join(sections))
 
 
@@ -199,3 +227,74 @@ def test_nonzero_hbond_term_fails_closed(tmp_path):
 
     assert result.returncode != 0
     assert "AMBER 10-12 nonbonded terms are not supported" in output
+
+
+_FOUR_ATOM_COORDINATES = [
+    (0.0, 1.0, 0.0),
+    (0.0, 0.0, 0.0),
+    (1.0, 0.0, 0.0),
+    (1.0, 0.0, 1.0),
+]
+
+
+def _four_atom_nb14_options(**overrides):
+    options = {
+        "atom_types": [1, 1, 2, 2],
+        "normal_a": [729.0, 200.0, 300.0],
+        "normal_b": [27.0, 20.0, 30.0],
+        "lj14_a": [729.0, 400.0, 500.0],
+        "lj14_b": [54.0, 40.0, 50.0],
+        "dihedral_rows": [(0, 3, 6, 9, 1)],
+        "excluded_counts": [3, 2, 1, 0],
+        "excluded_list": [2, 3, 4, 3, 4, 4],
+    }
+    options.update(overrides)
+    return options
+
+
+def test_chamber_lj14_matrix_uses_nonbonded_parm_index(tmp_path):
+    result, mdout_path = _run_sponge(
+        tmp_path,
+        _FOUR_ATOM_COORDINATES,
+        **_four_atom_nb14_options(),
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode == 0, output
+    assert "non-bond 14 numbers is 1" in output
+    assert math.isclose(
+        _extract_mdout_term(mdout_path, "nb14_LJ"), -0.5, abs_tol=0.01
+    )
+
+
+def test_missing_chamber_lj14_matrix_falls_back_to_ordinary_lj(tmp_path):
+    result, mdout_path = _run_sponge(
+        tmp_path,
+        _FOUR_ATOM_COORDINATES,
+        **_four_atom_nb14_options(
+            normal_b=[54.0, 20.0, 30.0],
+            lj14_a=None,
+            lj14_b=None,
+        ),
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode == 0, output
+    assert math.isclose(
+        _extract_mdout_term(mdout_path, "nb14_LJ"), -0.5, abs_tol=0.01
+    )
+
+
+def test_chamber_lj14_coefficients_must_be_complete(tmp_path):
+    result, _mdout_path = _run_sponge(
+        tmp_path,
+        _FOUR_ATOM_COORDINATES,
+        **_four_atom_nb14_options(lj14_b=None),
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode != 0
+    assert (
+        "LENNARD_JONES_14_ACOEF and LENNARD_JONES_14_BCOEF must either both "
+        "be present or both be absent"
+    ) in output

--- a/benchmarks/comparison/tests/amber/tests/comp_amber_nb14.py
+++ b/benchmarks/comparison/tests/amber/tests/comp_amber_nb14.py
@@ -1,0 +1,201 @@
+import math
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+_PERMUTED_TWO_TYPE_NPI = [3, 1, 1, 2]
+
+
+def _flag(name, fmt, values, items_per_line=10):
+    lines = [f"%FLAG {name}", f"%FORMAT({fmt})"]
+    rendered = [str(value) for value in values]
+    for start in range(0, len(rendered), items_per_line):
+        lines.append(" ".join(rendered[start : start + items_per_line]))
+    return "\n".join(lines) + "\n"
+
+
+def _write_prmtop(
+    path,
+    *,
+    atom_types,
+    normal_a,
+    normal_b,
+    nonbonded_parm_index=None,
+    hbond_a=None,
+    hbond_b=None,
+    excluded_counts=None,
+    excluded_list=(),
+):
+    atom_types = list(atom_types)
+    atom_count = len(atom_types)
+    atom_type_count = max(atom_types)
+    if nonbonded_parm_index is None:
+        nonbonded_parm_index = _PERMUTED_TWO_TYPE_NPI
+    if excluded_counts is None:
+        excluded_counts = [0] * atom_count
+    hbond_type_count = max(
+        len(hbond_a) if hbond_a is not None else 0,
+        len(hbond_b) if hbond_b is not None else 0,
+    )
+
+    pointers = [0] * 31
+    pointers[0] = atom_count  # NATOM
+    pointers[1] = atom_type_count  # NTYPES
+    pointers[10] = len(excluded_list)  # NNB
+    pointers[11] = 1  # NRES
+    pointers[19] = hbond_type_count  # NPHB
+    pointers[27] = 1  # IFBOX
+
+    sections = [
+        "%VERSION VERSION_STAMP = V0001.000 DATE = 01/01/70 00:00:00\n",
+        _flag("POINTERS", "10I8", pointers),
+        _flag("CHARGE", "5E16.8", [0.0] * atom_count, 5),
+        _flag("MASS", "5E16.8", [12.0] * atom_count, 5),
+        _flag("ATOM_TYPE_INDEX", "10I8", atom_types),
+        _flag(
+            "NONBONDED_PARM_INDEX",
+            "10I8",
+            nonbonded_parm_index,
+        ),
+        _flag("NUMBER_EXCLUDED_ATOMS", "10I8", excluded_counts),
+        _flag("RESIDUE_POINTER", "10I8", [1]),
+    ]
+    if hbond_a is not None:
+        sections.append(_flag("HBOND_ACOEF", "5E16.8", hbond_a, 5))
+    if hbond_b is not None:
+        sections.append(_flag("HBOND_BCOEF", "5E16.8", hbond_b, 5))
+    sections.extend(
+        [
+            _flag("LENNARD_JONES_ACOEF", "3E24.16", normal_a, 3),
+            _flag("LENNARD_JONES_BCOEF", "3E24.16", normal_b, 3),
+            _flag("EXCLUDED_ATOMS_LIST", "10I8", excluded_list),
+        ]
+    )
+    path.write_text("".join(sections))
+
+
+def _write_rst7(path, coordinates):
+    flat_coordinates = [
+        value for coordinate in coordinates for value in coordinate
+    ]
+    coordinate_lines = []
+    for start in range(0, len(flat_coordinates), 6):
+        coordinate_lines.append(
+            "".join(
+                f"{value:12.7f}"
+                for value in flat_coordinates[start : start + 6]
+            )
+        )
+    path.write_text(
+        "\n".join(
+            [
+                "synthetic AMBER NONBONDED_PARM_INDEX test",
+                f"{len(coordinates):6d}",
+                *coordinate_lines,
+                "  50.0000000  50.0000000  50.0000000",
+                "  90.0000000  90.0000000  90.0000000",
+            ]
+        )
+        + "\n"
+    )
+
+
+def _write_mdin(path, prmtop_path, rst7_path, mdout_path):
+    path.write_text(
+        textwrap.dedent(
+            f"""
+            md_name = "synthetic_amber_nb14"
+            mode = "nve"
+            step_limit = 0
+            dt = 0
+            cutoff = 8.0
+            amber_parm7 = {str(prmtop_path)!r}
+            amber_rst7 = {str(rst7_path)!r}
+            mdout = {str(mdout_path)!r}
+            print_zeroth_frame = 1
+            write_mdout_interval = 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+
+def _run_sponge(tmp_path, coordinates, **prmtop_options):
+    prmtop_path = tmp_path / "synthetic.prmtop"
+    rst7_path = tmp_path / "synthetic.rst7"
+    mdin_path = tmp_path / "mdin.spg.toml"
+    mdout_path = tmp_path / "mdout.txt"
+    _write_prmtop(prmtop_path, **prmtop_options)
+    _write_rst7(rst7_path, coordinates)
+    _write_mdin(mdin_path, prmtop_path, rst7_path, mdout_path)
+    result = subprocess.run(
+        [os.environ.get("SPONGE_BIN", "SPONGE"), "-mdin", str(mdin_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    return result, mdout_path
+
+
+def _extract_mdout_term(mdout_path, term_name):
+    lines = Path(mdout_path).read_text().splitlines()
+    headers = lines[0].split()
+    values = lines[1].split()
+    assert len(headers) == len(values)
+    return float(dict(zip(headers, values))[term_name])
+
+
+def test_nonbonded_parm_index_remaps_ordinary_lj_matrix(tmp_path):
+    result, mdout_path = _run_sponge(
+        tmp_path,
+        [(0.0, 0.0, 0.0), (math.sqrt(3.0), 0.0, 0.0)],
+        atom_types=[1, 2],
+        # The cross term is source entry 1, not canonical array slot 2.
+        normal_a=[729.0, 200.0, 300.0],
+        normal_b=[54.0, 20.0, 30.0],
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode == 0, output
+    assert math.isclose(
+        _extract_mdout_term(mdout_path, "LJ_short"), -1.0, abs_tol=0.01
+    )
+
+
+def test_zero_hbond_placeholder_maps_to_zero_lj(tmp_path):
+    result, mdout_path = _run_sponge(
+        tmp_path,
+        [(0.0, 0.0, 0.0), (math.sqrt(3.0), 0.0, 0.0)],
+        atom_types=[1, 2],
+        normal_a=[729.0, 200.0, 300.0],
+        normal_b=[54.0, 20.0, 30.0],
+        nonbonded_parm_index=[3, -1, -1, 2],
+        hbond_a=[0.0],
+        hbond_b=[0.0],
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode == 0, output
+    assert math.isclose(
+        _extract_mdout_term(mdout_path, "LJ_short"), 0.0, abs_tol=0.01
+    )
+
+
+def test_nonzero_hbond_term_fails_closed(tmp_path):
+    result, _mdout_path = _run_sponge(
+        tmp_path,
+        [(0.0, 0.0, 0.0), (math.sqrt(3.0), 0.0, 0.0)],
+        atom_types=[1, 2],
+        normal_a=[729.0, 200.0, 300.0],
+        normal_b=[54.0, 20.0, 30.0],
+        nonbonded_parm_index=[3, -1, -1, 2],
+        hbond_a=[1.0],
+        hbond_b=[0.0],
+    )
+    output = result.stdout + "\n" + result.stderr
+
+    assert result.returncode != 0
+    assert "AMBER 10-12 nonbonded terms are not supported" in output

--- a/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_features.py
+++ b/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_features.py
@@ -1,8 +1,11 @@
 import json
+import math
 import os
 import subprocess
 import textwrap
 from pathlib import Path
+
+import pytest
 
 
 def _toml_string(value):
@@ -15,6 +18,17 @@ def _gro_atom(resid, resname, atomname, atomnr, xyz):
         f"{resid:5d}{resname:<5}{atomname:>5}{atomnr:5d}"
         f"{x:8.3f}{y:8.3f}{z:8.3f}"
     )
+
+
+def _extract_mdout_term(mdout_path, term):
+    lines = mdout_path.read_text().splitlines()
+    headers = lines[0].split()
+    values = next(
+        line.split()
+        for line in reversed(lines[1:])
+        if line.strip() and line.lstrip()[0].isdigit()
+    )
+    return float(dict(zip(headers, values))[term])
 
 
 def test_direct_gromacs_topgro_accepts_settles_constraints_and_cmap(tmp_path):
@@ -132,3 +146,112 @@ def test_direct_gromacs_topgro_accepts_settles_constraints_and_cmap(tmp_path):
     assert "constrain pair number is 4" in output
     assert "rigid triangle numbers is 1" in output
     assert "rigid pair numbers is 1" in output
+
+
+def test_direct_gromacs_harmonic_improper_uses_half_force_constant(tmp_path):
+    top_path = tmp_path / "topol.top"
+    gro_path = tmp_path / "conf.gro"
+    mdin_path = tmp_path / "mdin.spg.toml"
+    mdout_path = tmp_path / "mdout.txt"
+
+    top_path.write_text(
+        textwrap.dedent(
+            """
+            [ defaults ]
+            1 2 yes 1.0 1.0
+
+            [ atomtypes ]
+            A A 12.0 0.0 A 0.0 0.0
+            B B 12.0 0.0 A 0.0 0.0
+            C C 12.0 0.0 A 0.0 0.0
+            D D 12.0 0.0 A 0.0 0.0
+
+            [ dihedraltypes ]
+            A B C D 2 0.0 8.368
+
+            [ moleculetype ]
+            IMPLICIT 0
+
+            [ atoms ]
+            1 A 1 IMP A 1 0.0 12.0
+            2 B 1 IMP B 2 0.0 12.0
+            3 C 1 IMP C 3 0.0 12.0
+            4 D 1 IMP D 4 0.0 12.0
+
+            [ dihedrals ]
+            1 2 3 4 2
+
+            [ moleculetype ]
+            EXPLICIT 0
+
+            [ atoms ]
+            1 A 1 EXP A 1 0.0 12.0
+            2 B 1 EXP B 2 0.0 12.0
+            3 C 1 EXP C 3 0.0 12.0
+            4 D 1 EXP D 4 0.0 12.0
+
+            [ dihedrals ]
+            1 2 3 4 2 0.0 8.368
+
+            [ system ]
+            harmonic improper convention
+
+            [ molecules ]
+            IMPLICIT 1
+            EXPLICIT 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+    gro_lines = [
+        "harmonic improper convention",
+        "8",
+        _gro_atom(1, "IMP", "A", 1, (0.000, 0.100, 0.000)),
+        _gro_atom(1, "IMP", "B", 2, (0.000, 0.000, 0.000)),
+        _gro_atom(1, "IMP", "C", 3, (0.100, 0.000, 0.000)),
+        _gro_atom(1, "IMP", "D", 4, (0.100, 0.000, 0.100)),
+        _gro_atom(2, "EXP", "A", 5, (1.000, 0.100, 0.000)),
+        _gro_atom(2, "EXP", "B", 6, (1.000, 0.000, 0.000)),
+        _gro_atom(2, "EXP", "C", 7, (1.100, 0.000, 0.000)),
+        _gro_atom(2, "EXP", "D", 8, (1.100, 0.000, 0.100)),
+        "   5.00000   5.00000   5.00000",
+    ]
+    gro_path.write_text("\n".join(gro_lines) + "\n")
+
+    mdin_path.write_text(
+        textwrap.dedent(
+            f"""
+            md_name = "direct_gromacs_harmonic_improper"
+            mode = "nve"
+            step_limit = 0
+            dt = 0
+            cutoff = 8.0
+            gromacs_top = {_toml_string(top_path)}
+            gromacs_gro = {_toml_string(gro_path)}
+            mdout = {_toml_string(mdout_path)}
+            print_zeroth_frame = 1
+            write_mdout_interval = 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+    result = subprocess.run(
+        [os.environ.get("SPONGE_BIN", "SPONGE"), "-mdin", str(mdin_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stdout + "\n" + result.stderr
+    assert "dihedral_numbers is 2" in result.stdout + result.stderr
+
+    # k=8.368 kJ/mol/rad^2 is 2 kcal/mol/rad^2. Both impropers have
+    # phi=pi/2 and each contributes 1/2*k*phi^2.
+    expected = 2.0 * 0.5 * (8.368 / 4.184) * (math.pi / 2.0) ** 2
+    assert _extract_mdout_term(
+        mdout_path, "improper_dihedral"
+    ) == pytest.approx(expected, abs=0.02)

--- a/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_nonbond_params.py
+++ b/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_nonbond_params.py
@@ -1,0 +1,316 @@
+import json
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def _toml_string(value):
+    return json.dumps(os.fspath(value))
+
+
+def _gro_atom(resid, resname, atomname, atomnr, x):
+    return (
+        f"{resid:5d}{resname:<5}{atomname:>5}{atomnr:5d}"
+        f"{x:8.3f}{0.0:8.3f}{0.0:8.3f}"
+    )
+
+
+def _run_two_atom_topology(
+    tmp_path, topology, *, distance_nm=0.5, atom_names=("A", "B")
+):
+    top_path = tmp_path / "topol.top"
+    gro_path = tmp_path / "conf.gro"
+    mdin_path = tmp_path / "mdin.spg.toml"
+    mdout_path = tmp_path / "mdout.txt"
+
+    top_path.write_text(textwrap.dedent(topology).strip() + "\n")
+    gro_path.write_text(
+        "\n".join(
+            [
+                "nonbond params test",
+                "2",
+                _gro_atom(1, "PAIR", atom_names[0], 1, 0.0),
+                _gro_atom(1, "PAIR", atom_names[1], 2, distance_nm),
+                "   5.00000   5.00000   5.00000",
+            ]
+        )
+        + "\n"
+    )
+    mdin_path.write_text(
+        textwrap.dedent(
+            f"""
+            md_name = "direct_gromacs_nonbond_params"
+            mode = "nve"
+            step_limit = 0
+            dt = 0
+            cutoff = 8.0
+            gromacs_top = {_toml_string(top_path)}
+            gromacs_gro = {_toml_string(gro_path)}
+            mdout = {_toml_string(mdout_path)}
+            print_zeroth_frame = 1
+            write_mdout_interval = 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+    result = subprocess.run(
+        [os.environ.get("SPONGE_BIN", "SPONGE"), "-mdin", str(mdin_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    return result, mdout_path
+
+
+def _extract_mdout_term(mdout_path, term_name):
+    lines = Path(mdout_path).read_text().splitlines()
+    headers = lines[0].split()
+    values = lines[1].split()
+    assert len(headers) == len(values)
+    return float(dict(zip(headers, values))[term_name])
+
+
+def _lj_energy(sigma_nm, epsilon_kj, distance_nm, scale=1.0):
+    sigma_over_r = abs(sigma_nm) / distance_nm
+    attractive = 0.0 if sigma_nm < 0.0 else sigma_over_r**6
+    return scale * 4.0 * (epsilon_kj / 4.184) * (sigma_over_r**12 - attractive)
+
+
+def test_nonbond_params_override_main_lj_without_fudge_and_keep_named_types(
+    tmp_path,
+):
+    result, mdout_path = _run_two_atom_topology(
+        tmp_path,
+        """
+        [ defaults ]
+        1 2 yes 0.25 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.30 0.4184
+        B B 12.0 0.0 A 0.30 0.4184
+
+        [ nonbond_params ]
+        A B 1 0.25 0.4184
+        B A 1 0.40 4.184
+
+        [ moleculetype ]
+        PAIR 0
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 B 1 PAIR B 2 0.0 12.0
+
+        [ system ]
+        main nonbond override
+
+        [ molecules ]
+        PAIR 1
+        """,
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0, output
+    assert "atom_LJ_type_number is 2" in output
+    assert _extract_mdout_term(mdout_path, "LJ_short") == pytest.approx(
+        _lj_energy(0.40, 4.184, 0.5), abs=0.011
+    )
+
+
+def test_nonbond_params_negative_sigma_is_purely_repulsive(tmp_path):
+    result, mdout_path = _run_two_atom_topology(
+        tmp_path,
+        """
+        [ defaults ]
+        1 2 yes 1.0 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.30 0.4184
+        B B 12.0 0.0 A 0.30 0.4184
+
+        [ nonbond_params ]
+        A B 1 -0.40 4.184
+
+        [ moleculetype ]
+        PAIR 0
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 B 1 PAIR B 2 0.0 12.0
+
+        [ system ]
+        negative sigma override
+
+        [ molecules ]
+        PAIR 1
+        """,
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0, output
+    observed = _extract_mdout_term(mdout_path, "LJ_short")
+    assert observed == pytest.approx(_lj_energy(-0.40, 4.184, 0.5), abs=0.011)
+    assert observed > 0.0
+
+
+def test_nonbond_params_leave_unmatched_type_pair_on_combination_rule(tmp_path):
+    result, mdout_path = _run_two_atom_topology(
+        tmp_path,
+        """
+        [ defaults ]
+        1 2 yes 0.25 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.20 0.4184
+        B B 12.0 0.0 A 0.20 0.4184
+        C C 12.0 0.0 A 0.60 1.6736
+
+        [ nonbond_params ]
+        A B 1 0.10 0.0
+
+        [ moleculetype ]
+        PAIR 0
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 C 1 PAIR C 2 0.0 12.0
+
+        [ system ]
+        unmatched nonbond pair
+
+        [ molecules ]
+        PAIR 1
+        """,
+        atom_names=("A", "C"),
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0, output
+    assert _extract_mdout_term(mdout_path, "LJ_short") == pytest.approx(
+        _lj_energy(0.40, 0.8368, 0.5), abs=0.011
+    )
+
+
+@pytest.mark.parametrize(
+    ("pairtypes", "pair_entry", "sigma_nm", "epsilon_kj", "scale"),
+    [
+        ("", "1 2 1", 0.40, 4.184, 0.25),
+        ("[ pairtypes ]\nA B 1 0.30 8.368", "1 2 1", 0.30, 8.368, 1.0),
+        (
+            "[ pairtypes ]\nA B 1 0.30 8.368",
+            "1 2 1 0.45 4.184",
+            0.45,
+            4.184,
+            1.0,
+        ),
+    ],
+    ids=["generated_override_then_fudge", "pairtypes", "inline"],
+)
+def test_pair_parameter_priority_and_fudge_scope(
+    tmp_path,
+    pairtypes,
+    pair_entry,
+    sigma_nm,
+    epsilon_kj,
+    scale,
+):
+    result, mdout_path = _run_two_atom_topology(
+        tmp_path,
+        f"""
+        [ defaults ]
+        1 2 yes 0.25 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.20 0.4184
+        B B 12.0 0.0 A 0.20 0.4184
+
+        [ nonbond_params ]
+        A B 1 0.40 4.184
+
+        {pairtypes}
+
+        [ moleculetype ]
+        PAIR 1
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 B 1 PAIR B 2 0.0 12.0
+
+        [ bonds ]
+        1 2 1 0.50 0.0
+
+        [ pairs ]
+        {pair_entry}
+
+        [ system ]
+        pair parameter priority
+
+        [ molecules ]
+        PAIR 1
+        """,
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0, output
+    assert _extract_mdout_term(mdout_path, "nb14_LJ") == pytest.approx(
+        _lj_energy(sigma_nm, epsilon_kj, 0.5, scale), abs=0.011
+    )
+
+
+@pytest.mark.parametrize(
+    ("entry", "error_fragment"),
+    [
+        ("A B 1 0.40", "expected exactly five fields"),
+        ("A B 1 0.40 4.184 extra", "expected exactly five fields"),
+        ("A B 2 0.40 4.184", "unsupported function"),
+        ("A B 1 invalid 4.184", "invalid numeric field"),
+        ("A UNKNOWN 1 0.40 4.184", "undefined GROMACS atom type 'UNKNOWN'"),
+    ],
+    ids=[
+        "too_few",
+        "too_many",
+        "unsupported_funct",
+        "invalid_value",
+        "unknown_type",
+    ],
+)
+def test_nonbond_params_reject_malformed_entries(
+    tmp_path, entry, error_fragment
+):
+    result, _ = _run_two_atom_topology(
+        tmp_path,
+        f"""
+        [ defaults ]
+        1 2 yes 0.25 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.30 0.4184
+        B B 12.0 0.0 A 0.30 0.4184
+
+        [ nonbond_params ]
+        {entry}
+
+        [ moleculetype ]
+        PAIR 0
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 B 1 PAIR B 2 0.0 12.0
+
+        [ system ]
+        malformed nonbond override
+
+        [ molecules ]
+        PAIR 1
+        """,
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode != 0
+    assert "spongeErrorBadFileFormat" in output
+    assert error_fragment in output


### PR DESCRIPTION
## Summary

- Honor Amber `NONBONDED_PARM_INDEX` and CHAMBER 1-4 Lennard-Jones coefficients.
- Apply GROMACS nonbond parameter overrides and correct harmonic improper coefficients.
- Add Amber and GROMACS regression coverage for these parsing paths.

## Validation

The four component changes were previously reviewed and merged into `lab/pku` as PRs #39 through #42.
