### PR TITLE
Fix Conda release publishing and runtime verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,13 +339,14 @@ jobs:
           set -euo pipefail
           raw_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pixi.toml | head -n 1)"
           conda_version="${raw_version//-/_}"
-          export PIXI_HOME="${RUNNER_TEMP}/pixi-home"
+          smoke_dir="${RUNNER_TEMP}/sponge-conda-smoke"
 
-          pixi global install \
-            --channel https://conda.spongemm.cn \
-            --channel conda-forge \
+          pixi init "${smoke_dir}" --channel conda-forge
+          pixi project channel add --manifest-path "${smoke_dir}" \
+            https://conda.spongemm.cn
+          pixi add --manifest-path "${smoke_dir}" \
             "sponge-cpu=${conda_version}"
-          "${PIXI_HOME}/bin/SPONGE" -v \
+          pixi run --manifest-path "${smoke_dir}" SPONGE -v \
             | tee "${RUNNER_TEMP}/sponge-version.txt"
           grep -F "v${raw_version}" "${RUNNER_TEMP}/sponge-version.txt"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/prips
+    outputs:
+      version: ${{ steps.prips-metadata.outputs.version }}
     permissions:
       contents: read
       id-token: write
@@ -156,10 +158,52 @@ jobs:
         run: |
           pixi run -e dev-cpu pip install --force-reinstall plugins/prips/dist/*.tar.gz
 
+      - name: Record PRIPS distribution metadata
+        id: prips-metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t sdists < <(compgen -G 'plugins/prips/dist/*.tar.gz')
+          if [[ "${#sdists[@]}" -ne 1 ]]; then
+            echo "::error::Expected exactly one PRIPS sdist, found ${#sdists[@]}."
+            exit 1
+          fi
+
+          version="$(pixi run -e dev-cpu python -c 'from importlib.metadata import version; print(version("prips"))')"
+          sha256="$(sha256sum "${sdists[0]}" | cut -d ' ' -f 1)"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "sha256=${sha256}" >> "${GITHUB_OUTPUT}"
+
       - name: Publish PRIPS package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: plugins/prips/dist/
+
+      - name: Verify PRIPS publication on PyPI
+        shell: bash
+        env:
+          PRIPS_VERSION: ${{ steps.prips-metadata.outputs.version }}
+          PRIPS_SHA256: ${{ steps.prips-metadata.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          metadata="${RUNNER_TEMP}/prips-pypi.json"
+
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error \
+              "https://pypi.org/pypi/prips/${PRIPS_VERSION}/json" \
+              --output "${metadata}" \
+              && jq -e --arg sha256 "${PRIPS_SHA256}" \
+                '.urls[] | select(.packagetype == "sdist" and .digests.sha256 == $sha256)' \
+                "${metadata}" > /dev/null; then
+              echo "Verified prips ${PRIPS_VERSION} on PyPI with SHA-256 ${PRIPS_SHA256}."
+              exit 0
+            fi
+            echo "Waiting for prips ${PRIPS_VERSION} to become visible on PyPI (${attempt}/12)..."
+            sleep 10
+          done
+
+          echo "::error::prips ${PRIPS_VERSION} was not visible on PyPI with the expected SHA-256."
+          exit 1
 
       - name: Stage PRIPS artifacts
         shell: bash
@@ -434,10 +478,10 @@ jobs:
 
             ### PRIPS（Python 接口）
 
-            下载本 Release Assets 中的 `prips-*.tar.gz`，然后执行：
+            PRIPS 已发布到 PyPI。安装与本 Release 对应的版本：
 
             ```bash
-            pip install ./prips-*.tar.gz
+            pip install "prips==${{ needs.release-prips-sdist.outputs.version }}"
             ```
 
             ### 从源码编译

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,8 +134,6 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/prips
-    outputs:
-      version: ${{ steps.prips-metadata.outputs.version }}
     permissions:
       contents: read
       id-token: write
@@ -158,52 +156,10 @@ jobs:
         run: |
           pixi run -e dev-cpu pip install --force-reinstall plugins/prips/dist/*.tar.gz
 
-      - name: Record PRIPS distribution metadata
-        id: prips-metadata
-        shell: bash
-        run: |
-          set -euo pipefail
-          mapfile -t sdists < <(compgen -G 'plugins/prips/dist/*.tar.gz')
-          if [[ "${#sdists[@]}" -ne 1 ]]; then
-            echo "::error::Expected exactly one PRIPS sdist, found ${#sdists[@]}."
-            exit 1
-          fi
-
-          version="$(pixi run -e dev-cpu python -c 'from importlib.metadata import version; print(version("prips"))')"
-          sha256="$(sha256sum "${sdists[0]}" | cut -d ' ' -f 1)"
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "sha256=${sha256}" >> "${GITHUB_OUTPUT}"
-
       - name: Publish PRIPS package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: plugins/prips/dist/
-
-      - name: Verify PRIPS publication on PyPI
-        shell: bash
-        env:
-          PRIPS_VERSION: ${{ steps.prips-metadata.outputs.version }}
-          PRIPS_SHA256: ${{ steps.prips-metadata.outputs.sha256 }}
-        run: |
-          set -euo pipefail
-          metadata="${RUNNER_TEMP}/prips-pypi.json"
-
-          for attempt in {1..12}; do
-            if curl --fail --silent --show-error \
-              "https://pypi.org/pypi/prips/${PRIPS_VERSION}/json" \
-              --output "${metadata}" \
-              && jq -e --arg sha256 "${PRIPS_SHA256}" \
-                '.urls[] | select(.packagetype == "sdist" and .digests.sha256 == $sha256)' \
-                "${metadata}" > /dev/null; then
-              echo "Verified prips ${PRIPS_VERSION} on PyPI with SHA-256 ${PRIPS_SHA256}."
-              exit 0
-            fi
-            echo "Waiting for prips ${PRIPS_VERSION} to become visible on PyPI (${attempt}/12)..."
-            sleep 10
-          done
-
-          echo "::error::prips ${PRIPS_VERSION} was not visible on PyPI with the expected SHA-256."
-          exit 1
 
       - name: Stage PRIPS artifacts
         shell: bash
@@ -478,10 +434,8 @@ jobs:
 
             ### PRIPS（Python 接口）
 
-            PRIPS 已发布到 PyPI。安装与本 Release 对应的版本：
-
             ```bash
-            pip install "prips==${{ needs.release-prips-sdist.outputs.version }}"
+            pip install prips
             ```
 
             ### 从源码编译

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,12 @@ jobs:
   release-prips-sdist:
     name: Release PRIPS sdist
     runs-on: ubuntu-22.04
+    environment:
+      name: pypi
+      url: https://pypi.org/p/prips
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -152,18 +156,10 @@ jobs:
         run: |
           pixi run -e dev-cpu pip install --force-reinstall plugins/prips/dist/*.tar.gz
 
-      - name: Upload PRIPS package with Twine
-        env:
-          TWINE_REPOSITORY_URL: ${{ secrets.TWINE_REPOSITORY_URL }}
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          if [[ -z "${TWINE_PASSWORD}" ]]; then
-            echo "::notice::PYPI_TOKEN is not configured; publishing the PRIPS sdist as a GitHub Release artifact only."
-            exit 0
-          fi
-          pixi run -e dev-cpu pip install --disable-pip-version-check twine
-          pixi run -e dev-cpu twine upload plugins/prips/dist/*.tar.gz
+      - name: Publish PRIPS package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: plugins/prips/dist/
 
       - name: Stage PRIPS artifacts
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,10 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
+          if [[ -z "${TWINE_PASSWORD}" ]]; then
+            echo "::notice::PYPI_TOKEN is not configured; publishing the PRIPS sdist as a GitHub Release artifact only."
+            exit 0
+          fi
           pixi run -e dev-cpu pip install --disable-pip-version-check twine
           pixi run -e dev-cpu twine upload plugins/prips/dist/*.tar.gz
 
@@ -312,11 +316,45 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
 
+  verify-conda-channel:
+    name: Verify published conda package
+    runs-on: ubuntu-22.04
+    needs:
+      - release-sponge-conda
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          run-install: false
+
+      - name: Install and run SPONGE from the public channel
+        shell: bash
+        run: |
+          set -euo pipefail
+          raw_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pixi.toml | head -n 1)"
+          conda_version="${raw_version//-/_}"
+          export PIXI_HOME="${RUNNER_TEMP}/pixi-home"
+
+          pixi global install \
+            --channel https://conda.spongemm.cn \
+            --channel conda-forge \
+            "sponge-cpu=${conda_version}"
+          "${PIXI_HOME}/bin/SPONGE" -v \
+            | tee "${RUNNER_TEMP}/sponge-version.txt"
+          grep -F "v${raw_version}" "${RUNNER_TEMP}/sponge-version.txt"
+
   publish-release:
     name: Publish GitHub Release
     runs-on: ubuntu-22.04
     needs:
       - release-sponge-conda
+      - verify-conda-channel
       - release-prips-sdist
       - release-windows-installer
       - release-docker
@@ -365,13 +403,13 @@ jobs:
             **pixi：**
 
             ```bash
-            pixi global install --channel https://conda.spongemm.cn/conda sponge-cuda13
+            pixi global install --channel https://conda.spongemm.cn --channel conda-forge sponge-cuda13
             ```
 
             **conda / mamba / micromamba：**
 
             ```bash
-            conda install -c https://conda.spongemm.cn/conda sponge-cuda13
+            conda install -c https://conda.spongemm.cn -c conda-forge sponge-cuda13
             ```
 
             ### Windows 安装包
@@ -399,8 +437,10 @@ jobs:
 
             ### PRIPS（Python 接口）
 
+            下载本 Release Assets 中的 `prips-*.tar.gz`，然后执行：
+
             ```bash
-            pip install prips
+            pip install ./prips-*.tar.gz
             ```
 
             ### 从源码编译

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SPONGE
 
-! 注意：当前仓库版本为 SPONGE2 `v2.0.0-beta.1` 预发布版本
+! 注意：当前仓库版本为 SPONGE2 `v2.0.0-beta.2` 预发布版本
 
 [English](README_en.md)
 

--- a/README_en.md
+++ b/README_en.md
@@ -1,6 +1,6 @@
 # SPONGE
 
-! Note: The current repository version is the SPONGE2 `v2.0.0-beta.1` prerelease
+! Note: The current repository version is the SPONGE2 `v2.0.0-beta.2` prerelease
 
 [中文](README.md)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,43 +44,43 @@ packages instead of building from source.
 | `sponge-cpu` | CPU only | Linux x86_64 / aarch64, Windows x64, macOS ARM64 |
 | `sponge-cpu-mpi` | CPU + MPI | Linux x86_64 / aarch64 |
 
-### Install with pixi global
+The commands below use `sponge-cpu` as an example. Replace it with another
+package from the table when appropriate.
+
+### Install in a Pixi project
+
+Create a Pixi project, add the SPONGE channel, and install the package into the
+project environment:
 
 ```bash
+pixi init sponge-project --channel conda-forge
+cd sponge-project
 pixi project channel add https://conda.spongemm.cn
-pixi add sponge-xxx
+pixi add sponge-cpu
+pixi run SPONGE -v
 ```
 
-## Build SPONGE
+If you are already in a Pixi project that uses `conda-forge`, only the last
+three commands are needed.
 
-### Choose an environment
+### Install globally with Pixi
 
-Pick the environment that matches your hardware:
-
-| Environment | Hardware |
-|-------------|----------|
-| `dev-cuda13` | NVIDIA GPU (recommended) |
-| `dev-cuda12` | NVIDIA GPU (older drivers) |
-| `dev-hip` | AMD GPU / Hygon DCU (requires system-installed HIP/ROCm) |
-| `dev-cpu` | CPU |
-| `dev-cpu-mpi` | CPU + MPI |
-
-### Compile
+Install SPONGE into a Pixi-managed global environment when you want to run it
+outside a project:
 
 ```bash
-pixi install -e dev-cuda13          # install dependencies
-pixi run -e dev-cuda13 configure    # CMake configure
-pixi run -e dev-cuda13 compile      # build
+pixi global install \
+  --channel https://conda.spongemm.cn \
+  --channel conda-forge \
+  sponge-cpu
+SPONGE -v
 ```
 
-The `SPONGE` binary is installed into the pixi environment upon completion.
+## Optional: Build SPONGE from source
 
-### Verify
-
-```bash
-pixi run -e dev-cuda13 which SPONGE
-pixi run -e dev-cuda13 SPONGE --help
-```
+Most users should install a binary distribution above. To compile SPONGE from
+source or set up a development environment, follow the
+[Build Guide](build-guide.md).
 
 ## Run a simulation
 
@@ -101,13 +101,27 @@ target_temperature = 300.0
 write_information_interval = 1000
 ```
 
-Run:
+Use the command that matches how SPONGE was installed.
+
+For a global installation:
+
+```bash
+SPONGE -mdin mdin.spg.toml
+```
+
+For an installation in a Pixi project:
+
+```bash
+pixi run SPONGE -mdin mdin.spg.toml
+```
+
+For an optional source build in a development environment:
 
 ```bash
 pixi run -e dev-cuda13 SPONGE -mdin mdin.spg.toml
 ```
 
-Or enter a shell first:
+You can also enter that development environment first:
 
 ```bash
 pixi shell -e dev-cuda13
@@ -115,6 +129,9 @@ SPONGE -mdin mdin.spg.toml
 ```
 
 ## Run benchmarks
+
+The benchmark tasks are available from a source checkout with a development
+environment installed:
 
 ```bash
 pixi run -e dev-cuda13 perf-amber       # AMBER force field performance

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,8 +47,19 @@ packages instead of building from source.
 ### Install with pixi global
 
 ```bash
-pixi project channel add https://conda.spongemm.cn
-pixi add sponge-xxx
+pixi global install --channel https://conda.spongemm.cn --channel conda-forge sponge-cpu
+SPONGE -v
+```
+
+Replace `sponge-cpu` with the package matching your hardware from the table
+above. The public SPONGE channel is `https://conda.spongemm.cn`; dependencies
+are resolved from conda-forge automatically.
+
+### Install with conda, mamba, or micromamba
+
+```bash
+conda install -c https://conda.spongemm.cn -c conda-forge sponge-cpu
+SPONGE -v
 ```
 
 ## Build SPONGE

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,19 +47,8 @@ packages instead of building from source.
 ### Install with pixi global
 
 ```bash
-pixi global install --channel https://conda.spongemm.cn --channel conda-forge sponge-cpu
-SPONGE -v
-```
-
-Replace `sponge-cpu` with the package matching your hardware from the table
-above. The public SPONGE channel is `https://conda.spongemm.cn`; dependencies
-are resolved from conda-forge automatically.
-
-### Install with conda, mamba, or micromamba
-
-```bash
-conda install -c https://conda.spongemm.cn -c conda-forge sponge-cpu
-SPONGE -v
+pixi project channel add https://conda.spongemm.cn
+pixi add sponge-xxx
 ```
 
 ## Build SPONGE

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ Create a Pixi project, add the SPONGE channel, and install the package into the
 project environment:
 
 ```bash
-pixi init sponge-project --channel conda-forge
+pixi init sponge-project
 cd sponge-project
 pixi project channel add https://conda.spongemm.cn
 pixi add sponge-cpu

--- a/packaging/conda.py
+++ b/packaging/conda.py
@@ -36,10 +36,13 @@ PATCH_TOOL_BY_SYSTEM = {
     "linux": "patchelf",
     "darwin": "install_name_tool",
 }
+COMMON_RUNTIME_DEPENDENCIES = [
+    "hdf5 >=2.1,<2.2",
+]
 RUNTIME_DEPENDENCIES = {
     "cpu": {
         "linux-64": [
-            "mkl >=2025",
+            "mkl >=2025,<2026",
             "libllvm22 >=22.1,<23",
             "libclang-cpp >=22.1,<23",
             "libgomp",
@@ -57,7 +60,7 @@ RUNTIME_DEPENDENCIES = {
             "libgcc-ng",
         ],
         "win-64": [
-            "mkl >=2025",
+            "mkl >=2025,<2026",
             "libllvm22 >=22.1,<23",
             "libclang-cpp >=22.1,<23",
             "vc14_runtime",
@@ -76,7 +79,7 @@ RUNTIME_DEPENDENCIES = {
     },
     "cpu-mpi": {
         "linux-64": [
-            "mkl >=2025",
+            "mkl >=2025,<2026",
             "openmpi >=5,<6",
             "libllvm22 >=22.1,<23",
             "libclang-cpp >=22.1,<23",
@@ -305,7 +308,10 @@ def make_metadata(
             f"Known subdirs: {known_subdirs}"
         )
 
-    depends = list(variant_dependencies[subdir])
+    depends = [
+        *COMMON_RUNTIME_DEPENDENCIES,
+        *variant_dependencies[subdir],
+    ]
 
     return {
         "name": name,

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "SPONGE"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 description = "Simulation Package Toward Next GEneration of molecular modelling"
 channels = ["conda-forge"]
 platforms = ["linux-64", "linux-aarch64", "win-64", "osx-arm64"]

--- a/plugins/prips/prips/__init__.py
+++ b/plugins/prips/prips/__init__.py
@@ -2,4 +2,4 @@
 PRIPS: Python Runtime Interface Plugin of SPONGE
 """
 
-__version__ = "2.0.0-beta.1"
+__version__ = "2.0.0-beta.2"

--- a/skills/sponge-benchmark-creator/SKILL.md
+++ b/skills/sponge-benchmark-creator/SKILL.md
@@ -9,7 +9,7 @@ description: >
   - pixi task 接入
 ---
 
-本技能适配 SPONGE 版本号：2.0.0-beta.1
+本技能适配 SPONGE 版本号：2.0.0-beta.2
 
 用于新建或调整 `benchmarks/` 下的测试时，目标是让 benchmark 分类清楚、结构统一、可复用、可维护。
 

--- a/skills/sponge-build-guide/SKILL.md
+++ b/skills/sponge-build-guide/SKILL.md
@@ -5,7 +5,7 @@ description: >
   适用于 pixi 环境选择、CMake 配置、多后端编译、格式化、打包。
 ---
 
-本技能适配 SPONGE 版本号：2.0.0-beta.1
+本技能适配 SPONGE 版本号：2.0.0-beta.2
 
 用于指导 SPONGE 项目的构建流程，包括环境选择、CMake 配置、编译、格式化和打包。
 

--- a/skills/sponge-code-style/SKILL.md
+++ b/skills/sponge-code-style/SKILL.md
@@ -5,7 +5,7 @@ description: >
   适用于 C++、Python、CMake 的编码规范和格式化流程。
 ---
 
-本技能适配 SPONGE 版本号：2.0.0-beta.1
+本技能适配 SPONGE 版本号：2.0.0-beta.2
 
 ## 格式化工具与版本
 

--- a/skills/sponge-toml-input/SKILL.md
+++ b/skills/sponge-toml-input/SKILL.md
@@ -5,7 +5,7 @@ description: >
   适用于模拟参数设置、模块配置、输入输出文件指定等。
 ---
 
-本技能适配 SPONGE 版本号：2.0.0-beta.1
+本技能适配 SPONGE 版本号：2.0.0-beta.2
 
 SPONGE 的输入文件为 TOML 格式，默认文件名 `mdin.spg.toml`，通过 `-mdin` 参数指定：
 


### PR DESCRIPTION
## Summary
- publish PRIPS through PyPI Trusted Publishing; a PRIPS publishing failure now blocks the GitHub Release
- build and upload the SPONGE Conda package matrix, then install the exact CPU package from `https://conda.spongemm.cn` and run `SPONGE -v` before publishing the GitHub Release
- pin MKL to the build-compatible 2025 ABI and add the missing HDF5 runtime dependency
- correct the generated GitHub Release Conda channel URL and dependency channels
- clarify project-scoped and global binary installation in `docs/getting-started.md`, and keep source builds as an optional path through the Build Guide
- bump the prerelease version to v2.0.0-beta.2 and synchronize the documented versions

## Validation
- built the Linux CPU Conda package locally
- installed it into a clean Pixi environment and ran `pixi run SPONGE -v` successfully
- built `prips-2.0.0b2.tar.gz`
- parsed `.github/workflows/release.yml` as YAML
- verified the deploy key can access the remote Conda host

The tag-triggered Conda upload and PyPI OIDC publication will be exercised by the next prerelease tag; they are intentionally required to succeed before the GitHub Release is created.