### PR TITLE
fix(constrain): reject unsolvable SETTLE pair updates

### DIFF
--- a/SPONGE/constrain/settle.cpp
+++ b/SPONGE/constrain/settle.cpp
@@ -255,23 +255,170 @@ static __global__ void settle_triangle(
     }
 }
 
+static __device__ __forceinline__ unsigned int Settle_Float_Bits(float value)
+{
+#ifdef GPU_ARCH_NAME
+    return __float_as_uint(value);
+#elif defined(__GNUC__) || defined(__clang__)
+    unsigned int bits = 0;
+    static_assert(sizeof(bits) == sizeof(value),
+                  "SPONGE requires 32-bit IEEE-754 floats");
+    memcpy(&bits, &value, sizeof(value));
+    __asm__ __volatile__("" : "+r"(bits));
+    return bits;
+#else
+    unsigned int bits = 0;
+    memcpy(&bits, &value, sizeof(value));
+    return bits;
+#endif
+}
+
+static __device__ __forceinline__ unsigned long long Settle_Double_Bits(
+    double value)
+{
+#ifdef GPU_ARCH_NAME
+    return static_cast<unsigned long long>(__double_as_longlong(value));
+#else
+    unsigned long long bits = 0;
+    static_assert(sizeof(bits) == sizeof(value),
+                  "SPONGE requires 64-bit IEEE-754 doubles");
+    memcpy(&bits, &value, sizeof(value));
+#if defined(__GNUC__) || defined(__clang__)
+    __asm__ __volatile__("" : "+r"(bits));
+#endif
+    return bits;
+#endif
+}
+
+static __device__ __forceinline__ bool Settle_Double_Is_Finite(double value)
+{
+    const unsigned long long bits = Settle_Double_Bits(value);
+    return (bits & 0x7ff0000000000000ULL) != 0x7ff0000000000000ULL;
+}
+
+static __device__ __forceinline__ bool Settle_Double_Is_Finite_Nonnegative(
+    double value)
+{
+    const unsigned long long bits = Settle_Double_Bits(value);
+    const unsigned long long magnitude = bits & 0x7fffffffffffffffULL;
+    return (magnitude & 0x7ff0000000000000ULL) != 0x7ff0000000000000ULL &&
+           ((bits & 0x8000000000000000ULL) == 0ULL || magnitude == 0ULL);
+}
+
+static __device__ __forceinline__ double Settle_Pair_Precise_Radicand(
+    const VECTOR& r1, const VECTOR& r2, const float target,
+    double* perpendicular_squared)
+{
+    const double r1x = static_cast<double>(r1.x);
+    const double r1y = static_cast<double>(r1.y);
+    const double r1z = static_cast<double>(r1.z);
+    const double r2x = static_cast<double>(r2.x);
+    const double r2y = static_cast<double>(r2.y);
+    const double r2z = static_cast<double>(r2.z);
+    const double cross_x = r1y * r2z - r1z * r2y;
+    const double cross_y = r1z * r2x - r1x * r2z;
+    const double cross_z = r1x * r2y - r1y * r2x;
+    const double cross_squared =
+        cross_x * cross_x + cross_y * cross_y + cross_z * cross_z;
+    const double r2_squared = r2x * r2x + r2y * r2y + r2z * r2z;
+    const double target_double = static_cast<double>(target);
+    if (perpendicular_squared != NULL)
+    {
+        perpendicular_squared[0] = cross_squared / r2_squared;
+    }
+    return r2_squared * target_double * target_double - cross_squared;
+}
+
+// Keep the ordinary float path away from the tangent boundary.  Recompute an
+// uncertain discriminant so cancellation is not mistaken for either a valid
+// or a physically impossible constraint update.
+static __device__ __noinline__ bool Settle_Try_Precise_Pair_Solution(
+    const VECTOR& r1, const VECTOR& r2, const float target, float* k)
+{
+    const double radicand = Settle_Pair_Precise_Radicand(r1, r2, target, NULL);
+    const double r1r2 = static_cast<double>(r1.x) * r2.x +
+                        static_cast<double>(r1.y) * r2.y +
+                        static_cast<double>(r1.z) * r2.z;
+    const double r2r2 = static_cast<double>(r2.x) * r2.x +
+                        static_cast<double>(r2.y) * r2.y +
+                        static_cast<double>(r2.z) * r2.z;
+    if (!Settle_Double_Is_Finite_Nonnegative(radicand) ||
+        !Settle_Double_Is_Finite_Nonnegative(r2r2) || !(r2r2 > 0.0))
+    {
+        return false;
+    }
+    const double precise_k = (sqrt(radicand) - r1r2) / r2r2;
+    const double maximum_float = static_cast<double>(FLT_MAX);
+    if (!Settle_Double_Is_Finite(precise_k) || precise_k > maximum_float ||
+        precise_k < -maximum_float)
+    {
+        return false;
+    }
+    const float narrowed_k = static_cast<float>(precise_k);
+    if ((Settle_Float_Bits(narrowed_k) & 0x7f800000U) == 0x7f800000U)
+    {
+        return false;
+    }
+    k[0] = narrowed_k;
+    return true;
+}
+
+static __device__ __forceinline__ void Settle_Fail_Invalid_Pair(
+    const int pair_i, const CONSTRAIN_PAIR& pair, const int* atom_local,
+    const VECTOR& r1, const VECTOR& r2, const float radicand, const float dt,
+    int* invalid_pair)
+{
+#ifdef GPU_ARCH_NAME
+    double perpendicular_squared = 0.0;
+    const double precise_radicand = Settle_Pair_Precise_Radicand(
+        r1, r2, pair.constant_r, &perpendicular_squared);
+    const double perpendicular =
+        Settle_Double_Is_Finite_Nonnegative(perpendicular_squared)
+            ? sqrt(perpendicular_squared)
+            : -1.0;
+    printf(
+        "Fatal SPONGE SETTLE error: global atoms %d %d cannot produce a "
+        "finite real position-constraint update (target %.9g, "
+        "perpendicular %.17g, "
+        "radicand float/precise %.9g/%.17g, dt %.9g). "
+        "Reduce the timestep or minimize/equilibrate the input state.\n",
+        atom_local[pair.atom_i_serial], atom_local[pair.atom_j_serial],
+        static_cast<double>(pair.constant_r), perpendicular,
+        static_cast<double>(radicand), precise_radicand,
+        static_cast<double>(dt));
+#if defined(USE_CUDA)
+    asm volatile("trap;");
+#elif defined(USE_HIP)
+    __builtin_trap();
+#endif
+#else
+    (void)pair;
+    (void)atom_local;
+    (void)r1;
+    (void)r2;
+    (void)radicand;
+    (void)dt;
+    atomicExch(invalid_pair, pair_i);
+#endif
+}
+
 static __global__ void settle_pair(int num_task_local, CONSTRAIN_PAIR* pairs,
-                                   const float* d_mass, VECTOR* crd,
-                                   LTMatrix3 cell, LTMatrix3 rcell,
+                                   const int* atom_local, const float* d_mass,
+                                   VECTOR* crd, LTMatrix3 cell, LTMatrix3 rcell,
                                    VECTOR* last_pair_AB, float dt,
                                    float exp_gamma,
                                    float half_exp_gamma_plus_half, VECTOR* vel,
-                                   LTMatrix3* virial_tensor)
+                                   LTMatrix3* virial_tensor, int* invalid_pair)
 {
     CONSTRAIN_PAIR pair;
     VECTOR r1, r2, kr2;
-    float mA, mB, r0r0, r1r1, r1r2, r2r2, k;
+    float mA, mB, r0r0, r1r1, r1r2, r2r2, radicand, k;
 #ifdef USE_GPU
     int pair_i = blockIdx.x * blockDim.x + threadIdx.x;
     if (pair_i < num_task_local)
 #else
 #pragma omp parallel for private(pair, r1, r2, kr2, mA, mB, r0r0, r1r1, r1r2, \
-                                     r2r2, k)
+                                     r2r2, radicand, k)
     for (int pair_i = 0; pair_i < num_task_local; pair_i++)
 #endif
     {
@@ -288,7 +435,43 @@ static __global__ void settle_pair(int num_task_local, CONSTRAIN_PAIR* pairs,
         r1r2 = r1 * r2;
         r2r2 = r2 * r2;
 
-        k = (sqrt(r1r2 * r1r2 - r1r1 * r2r2 + r2r2 * r0r0) - r1r2) / r2r2;
+        const float projection_squared = r1r2 * r1r2;
+        const float length_product = r1r1 * r2r2;
+        const float target_product = r2r2 * r0r0;
+        radicand = projection_squared - length_product + target_product;
+        const float radicand_error_bound =
+            8.0f * FLT_EPSILON *
+            (projection_squared + length_product + target_product);
+        const unsigned int radicand_bits = Settle_Float_Bits(radicand);
+        const unsigned int radicand_magnitude = radicand_bits & 0x7fffffffU;
+        const unsigned int r2r2_bits = Settle_Float_Bits(r2r2);
+        const unsigned int r2r2_magnitude = r2r2_bits & 0x7fffffffU;
+        const bool finite_radicand =
+            (radicand_magnitude & 0x7f800000U) != 0x7f800000U;
+        const bool valid_r2r2 = (r2r2_bits & 0x80000000U) == 0U &&
+                                r2r2_magnitude != 0U &&
+                                (r2r2_magnitude & 0x7f800000U) != 0x7f800000U;
+        bool solved = false;
+        if (finite_radicand && valid_r2r2 && radicand > radicand_error_bound)
+        {
+            k = (sqrt(radicand) - r1r2) / r2r2;
+            solved = (Settle_Float_Bits(k) & 0x7f800000U) != 0x7f800000U;
+        }
+        else if (finite_radicand && valid_r2r2)
+        {
+            solved =
+                Settle_Try_Precise_Pair_Solution(r1, r2, pair.constant_r, &k);
+        }
+        if (!solved)
+        {
+            Settle_Fail_Invalid_Pair(pair_i, pair, atom_local, r1, r2, radicand,
+                                     dt, invalid_pair);
+#ifdef USE_GPU
+            return;
+#else
+            continue;
+#endif
+        }
         kr2 = k * r2;
 
         r1 = -mB * pair.constrain_k * kr2;
@@ -656,19 +839,61 @@ void SETTLE::Get_Local(const int* atom_local_id, const char* atom_local_label,
                  deviceMemcpyDeviceToHost);
 }
 
-void SETTLE::Do_SETTLE(const float* d_mass, VECTOR* crd, const LTMatrix3 cell,
+void SETTLE::Do_SETTLE(CONTROLLER* controller, const int* atom_local,
+                       const float* d_mass, VECTOR* crd, const LTMatrix3 cell,
                        const LTMatrix3 rcell, VECTOR* vel,
                        const int need_pressure, LTMatrix3* d_stress)
 {
     if (!is_initialized) return;
+#ifndef GPU_ARCH_NAME
+    int invalid_pair = -1;
+    int* invalid_pair_buffer = &invalid_pair;
+#else
+    int* invalid_pair_buffer = NULL;
+#endif
     Launch_Device_Kernel(settle_pair,
                          (num_pair_local + CONTROLLER::device_max_thread - 1) /
                              CONTROLLER::device_max_thread,
                          CONTROLLER::device_max_thread, 0, NULL, num_pair_local,
-                         d_pairs_local, d_mass, crd, cell, rcell, last_pair_AB,
-                         constrain->dt, constrain->v_factor,
+                         d_pairs_local, atom_local, d_mass, crd, cell, rcell,
+                         last_pair_AB, constrain->dt, constrain->v_factor,
                          constrain->x_factor, vel,
-                         virial_tensor + triangle_numbers);
+                         virial_tensor + triangle_numbers, invalid_pair_buffer);
+
+#ifndef GPU_ARCH_NAME
+    if (invalid_pair >= 0)
+    {
+        const CONSTRAIN_PAIR pair = d_pairs_local[invalid_pair];
+        const VECTOR r2 = last_pair_AB[invalid_pair];
+        const VECTOR r1 = Get_Periodic_Displacement(
+            crd[pair.atom_j_serial], crd[pair.atom_i_serial], cell, rcell);
+        const float r1r1 = r1 * r1;
+        const float r1r2 = r1 * r2;
+        const float r2r2 = r2 * r2;
+        const float target_squared = pair.constant_r * pair.constant_r;
+        const float radicand =
+            r1r2 * r1r2 - r1r1 * r2r2 + r2r2 * target_squared;
+        double perpendicular_squared = 0.0;
+        const double precise_radicand = Settle_Pair_Precise_Radicand(
+            r1, r2, pair.constant_r, &perpendicular_squared);
+        const double perpendicular =
+            Settle_Double_Is_Finite_Nonnegative(perpendicular_squared)
+                ? sqrt(perpendicular_squared)
+                : -1.0;
+        controller->Throw_Formatted_SPONGE_Error(
+            spongeErrorSimulationBreakDown, "SETTLE::Do_SETTLE",
+            "Reason:\n\tSETTLE global atoms %d %d cannot produce a finite "
+            "real position-constraint update (target %.9g, perpendicular "
+            "%.17g, radicand float/precise %.9g/%.17g, dt %.9g).\n"
+            "\tReduce the timestep or minimize/equilibrate the input "
+            "state.\n",
+            atom_local[pair.atom_i_serial], atom_local[pair.atom_j_serial],
+            static_cast<double>(pair.constant_r), perpendicular,
+            static_cast<double>(radicand), precise_radicand,
+            static_cast<double>(constrain->dt));
+        return;
+    }
+#endif
 
     Launch_Device_Kernel(
         settle_triangle,

--- a/SPONGE/constrain/settle.h
+++ b/SPONGE/constrain/settle.h
@@ -40,7 +40,8 @@ struct SETTLE
                                    const LTMatrix3 rcell);
 
     LTMatrix3* virial_tensor = NULL;
-    void Do_SETTLE(const float* d_mass, VECTOR* crd, const LTMatrix3 cell,
+    void Do_SETTLE(CONTROLLER* controller, const int* atom_local,
+                   const float* d_mass, VECTOR* crd, const LTMatrix3 cell,
                    const LTMatrix3 rcell, VECTOR* vel, const int need_pressure,
                    LTMatrix3* d_stress);
     void Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,

--- a/SPONGE/main.cpp
+++ b/SPONGE/main.cpp
@@ -1783,9 +1783,9 @@ void Main_Iteration()
                                            md_info.sys.freedom);
             }
 
-            settle.Do_SETTLE(dd.d_mass, dd.crd, md_info.pbc.cell,
-                             md_info.pbc.rcell, dd.vel, md_info.need_pressure,
-                             md_info.sys.d_stress);
+            settle.Do_SETTLE(&controller, dd.atom_local, dd.d_mass, dd.crd,
+                             md_info.pbc.cell, md_info.pbc.rcell, dd.vel,
+                             md_info.need_pressure, md_info.sys.d_stress);
             shake.Constrain(dd.atom_numbers, dd.crd, dd.vel, dd.d_mass_inverse,
                             dd.d_mass, md_info.pbc.cell, md_info.pbc.rcell,
                             md_info.need_pressure, md_info.sys.d_stress);

--- a/benchmarks/validation/misc/tests/settle_pair_guard_probe.cpp
+++ b/benchmarks/validation/misc/tests/settle_pair_guard_probe.cpp
@@ -1,0 +1,140 @@
+﻿#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+#include "constrain/settle.cpp"
+
+unsigned int CONTROLLER::device_max_thread = 64;
+
+namespace
+{
+
+bool Check_Pair(const char* name, const VECTOR& predicted,
+                const VECTOR& previous, const float target,
+                const bool should_fail)
+{
+    CONSTRAIN_PAIR pair = {};
+    pair.atom_i_serial = 0;
+    pair.atom_j_serial = 1;
+    pair.constant_r = target;
+    pair.constrain_k = 0.5f;
+    const int atom_local[2] = {10, 11};
+    const float mass[2] = {1.0f, 1.0f};
+    VECTOR coordinates[2] = {{0.0f, 0.0f, 0.0f}, predicted};
+    VECTOR velocities[2] = {{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}};
+    VECTOR last_pair[1] = {previous};
+    LTMatrix3 virial[1] = {{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}};
+    const VECTOR original_coordinates[2] = {coordinates[0], coordinates[1]};
+    const VECTOR original_velocities[2] = {velocities[0], velocities[1]};
+    const LTMatrix3 original_virial = virial[0];
+    const LTMatrix3 cell;
+    int invalid_pair = -1;
+
+    settle_pair(1, &pair, atom_local, mass, coordinates, cell, cell, last_pair,
+                0.002f, 1.0f, 1.0f, velocities, virial, &invalid_pair);
+
+    if (should_fail)
+    {
+        const bool unchanged =
+            std::memcmp(coordinates, original_coordinates,
+                        sizeof(coordinates)) == 0 &&
+            std::memcmp(velocities, original_velocities, sizeof(velocities)) ==
+                0 &&
+            std::memcmp(virial, &original_virial, sizeof(original_virial)) == 0;
+        if (invalid_pair == 0 && unchanged) return true;
+        std::fprintf(stderr, "%s did not fail before writing state\n", name);
+        return false;
+    }
+
+    const VECTOR constrained = coordinates[1] - coordinates[0];
+    const float distance = std::sqrt(constrained * constrained);
+    const bool finite_distance =
+        (Settle_Float_Bits(distance) & 0x7f800000U) != 0x7f800000U;
+    if (invalid_pair == -1 && finite_distance &&
+        std::fabs(distance - target) <= 2.0e-6f)
+        return true;
+    std::fprintf(stderr, "%s rejected a valid pair (distance %.9g)\n", name,
+                 static_cast<double>(distance));
+    return false;
+}
+
+bool Check_Float_Cancellation_Case()
+{
+    const VECTOR predicted = {1.50678098f, -2.55530214f, -1.57559633f};
+    const VECTOR previous = {-0.689187527f, 0.64532584f, 0.32950747f};
+    const float r1r1 = predicted * predicted;
+    const float r1r2 = predicted * previous;
+    const float r2r2 = previous * previous;
+    const float float_radicand = r1r2 * r1r2 - r1r1 * r2r2 + r2r2;
+    const double precise_radicand =
+        Settle_Pair_Precise_Radicand(predicted, previous, 1.0f, NULL);
+    if (!(float_radicand < 0.0f) ||
+        !Settle_Double_Is_Finite_Nonnegative(precise_radicand))
+    {
+        std::fprintf(
+            stderr,
+            "roundoff fixture no longer exercises float cancellation\n");
+        return false;
+    }
+    return Check_Pair("float-cancellation pair", predicted, previous, 1.0f,
+                      false);
+}
+
+bool Check_Float_False_Positive_Case()
+{
+    const VECTOR predicted = {0.769227564f, 0.589192092f, 1.73570371f};
+    const VECTOR previous = {0.359873652f, 0.728374541f, 0.583062232f};
+    const float r1r1 = predicted * predicted;
+    const float r1r2 = predicted * previous;
+    const float r2r2 = previous * previous;
+    const float float_radicand = r1r2 * r1r2 - r1r1 * r2r2 + r2r2;
+    const double precise_radicand =
+        Settle_Pair_Precise_Radicand(predicted, previous, 1.0f, NULL);
+    if (!(float_radicand > 0.0f) ||
+        Settle_Double_Is_Finite_Nonnegative(precise_radicand))
+    {
+        std::fprintf(stderr,
+                     "roundoff fixture no longer exercises a float false "
+                     "positive\n");
+        return false;
+    }
+    return Check_Pair("float-false-positive pair", predicted, previous, 1.0f,
+                      true);
+}
+
+bool Check_Precise_K_Overflow()
+{
+    const VECTOR predicted = {0.0f, 0.0f, 0.0f};
+    const VECTOR previous = {FLT_MIN, 0.0f, 0.0f};
+    float k = 123.0f;
+    return !Settle_Try_Precise_Pair_Solution(predicted, previous, FLT_MAX,
+                                             &k) &&
+           k == 123.0f;
+}
+
+}  // namespace
+
+int main()
+{
+    const VECTOR old_x = {1.0f, 0.0f, 0.0f};
+    const VECTOR ordinary = {1.2f, 0.2f, 0.0f};
+    const VECTOR just_inside = {0.0f, std::nextafter(1.0f, 0.0f), 0.0f};
+    const VECTOR tangent = {0.0f, 1.0f, 0.0f};
+    const VECTOR just_outside = {0.0f, std::nextafter(1.0f, 2.0f), 0.0f};
+    const VECTOR observed = {-0.511489868f, 1.50683594f, 0.117248535f};
+    const VECTOR observed_previous = {0.13999939f, 0.509994507f, 0.939994812f};
+
+    return Check_Pair("ordinary pair", ordinary, old_x, 1.0f, false) &&
+                   Check_Pair("inside-boundary pair", just_inside, old_x, 1.0f,
+                              false) &&
+                   Check_Pair("tangent pair", tangent, old_x, 1.0f, false) &&
+                   Check_Float_Cancellation_Case() &&
+                   Check_Float_False_Positive_Case() &&
+                   Check_Precise_K_Overflow() &&
+                   Check_Pair("outside-boundary pair", just_outside, old_x,
+                              1.0f, true) &&
+                   Check_Pair("observed negative-radicand pair", observed,
+                              observed_previous, 1.08000004f, true)
+               ? 0
+               : 1;
+}

--- a/benchmarks/validation/misc/tests/test_settle_pair_guard.py
+++ b/benchmarks/validation/misc/tests/test_settle_pair_guard.py
@@ -1,0 +1,89 @@
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+PROBE_SOURCE = Path(__file__).with_name("settle_pair_guard_probe.cpp")
+
+
+def _compiler_command():
+    configured = os.environ.get("CXX")
+    if configured:
+        return shlex.split(configured)
+    if sys.platform == "darwin" and Path("/usr/bin/clang++").is_file():
+        return ["/usr/bin/clang++"]
+    compiler = (
+        shutil.which("c++") or shutil.which("clang++") or shutil.which("g++")
+    )
+    if compiler is None:
+        pytest.skip("a C++17 compiler is required for the SETTLE pair probe")
+    return [compiler]
+
+
+def _dependency_include():
+    candidates = []
+    if os.environ.get("CONDA_PREFIX"):
+        candidates.append(Path(os.environ["CONDA_PREFIX"]) / "include")
+    candidates.append(
+        REPOSITORY_ROOT / ".pixi" / "envs" / "dev-cpu" / "include"
+    )
+    for candidate in candidates:
+        if (candidate / "omp.h").is_file() and (
+            candidate / "fftw3.h"
+        ).is_file():
+            return candidate
+    pytest.skip(
+        "OpenMP and FFTW headers are required for the SETTLE pair probe"
+    )
+
+
+def test_settle_pair_rejects_invalid_update_before_writing_state(tmp_path):
+    executable = tmp_path / "settle_pair_guard_probe"
+    dead_code_flags = (
+        ["-Wl,-dead_strip"]
+        if sys.platform == "darwin"
+        else ["-Wl,--gc-sections"]
+    )
+    compile_result = subprocess.run(
+        [
+            *_compiler_command(),
+            "-std=c++17",
+            "-DUSE_CPU",
+            "-DNO_GLOBAL_CONTROLLER",
+            "-O3",
+            "-march=native",
+            "-ffast-math",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-w",
+            f"-I{REPOSITORY_ROOT / 'SPONGE'}",
+            f"-I{_dependency_include()}",
+            str(PROBE_SOURCE),
+            str(REPOSITORY_ROOT / "SPONGE/common.cpp"),
+            *dead_code_flags,
+            "-o",
+            str(executable),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+    assert compile_result.returncode == 0, (
+        "failed to compile SETTLE pair guard probe\n"
+        f"stdout:\n{compile_result.stdout}\nstderr:\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run(
+        [str(executable)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr


### PR DESCRIPTION
### 问题

SETTLE 原子对更新中，根号内表达式（radicand）在极端几何下因浮点抵消变为负值或 NaN。旧代码对此不做检查，非法坐标静默写入状态并污染后续轨迹，直到能量爆炸或输出异常才被发现，定位困难。

### 方案

- 对 radicand 做 8ε 误差界判断：明显为负则判定不可解；在误差界内则用 double 精度重算一次，能挽救的按修正结果继续
- 确认不可解时拒绝写入状态并报错（`spongeErrorSimulationBreakDown`），而非静默传播 NaN
- 有限性/符号检查使用位级操作而非 `std::isfinite`：项目全局使用 `-ffast-math` / `--use_fast_math`，该选项下 `isfinite` 会被优化掉，位检测是唯一可靠手段
- CPU 路径走规范的 `Throw_SPONGE_Error`；GPU 路径目前为设备端打印 + trap。我们清楚这与 neighbor-list 溢出处理使用的 device flag + host 检查模式不同，选择 trap 是因为该状态出现时坐标已不可恢复，继续迭代没有意义；如维护者希望统一为 flag 模式，我们可以按 review 意见调整