### PR TITLE
fix(constrain): accept float-limited velocity projections

### DIFF
--- a/SPONGE/constrain/constrain.cpp
+++ b/SPONGE/constrain/constrain.cpp
@@ -57,6 +57,19 @@ void CONSTRAIN::Initial_Constrain(CONTROLLER* controller,
         fp = NULL;
     }
 
+    std::vector<int> constraint_degree(atom_numbers, 0);
+    maximum_constraint_degree = 0;
+    for (int i = 0; i < constrain_pair_numbers; ++i)
+    {
+        const CONSTRAIN_PAIR& pair = h_constrain_pair[i];
+        ++constraint_degree[pair.atom_i_serial];
+        ++constraint_degree[pair.atom_j_serial];
+        maximum_constraint_degree =
+            std::max(maximum_constraint_degree,
+                     std::max(constraint_degree[pair.atom_i_serial],
+                              constraint_degree[pair.atom_j_serial]));
+    }
+
     Device_Malloc_And_Copy_Safely(
         (void**)&d_constrain_pair, h_constrain_pair,
         sizeof(CONSTRAIN_PAIR) * constrain_pair_numbers);

--- a/SPONGE/constrain/constrain.h
+++ b/SPONGE/constrain/constrain.h
@@ -34,6 +34,7 @@ struct CONSTRAIN
 
     // 在实际计算中使用，体系总的constrain pair
     int constrain_pair_numbers = 0;
+    int maximum_constraint_degree = 0;
     CONSTRAIN_PAIR* h_constrain_pair = NULL;
     CONSTRAIN_PAIR* d_constrain_pair = NULL;
 

--- a/SPONGE/constrain/settle.cpp
+++ b/SPONGE/constrain/settle.cpp
@@ -1,5 +1,7 @@
 ﻿#include "settle.h"
 
+#include "velocity_projection.h"
+
 static __global__ void remember_triangle_BA_CA(
     const int num_triangle_local, const CONSTRAIN_TRIANGLE* triangles,
     const VECTOR* crd, const LTMatrix3 cell, const LTMatrix3 rcell,
@@ -720,7 +722,9 @@ compute_velocity_constraint_correction_settle(
         return false;
     }
 
-    VECTOR v_diff = vel[atom_i] - vel[atom_j];
+    const VECTOR velocity_i = vel[atom_i];
+    const VECTOR velocity_j = vel[atom_j];
+    VECTOR v_diff = velocity_i - velocity_j;
     float denom = (mass_i_inverse + mass_j_inverse) * dr2;
     if (denom < 1e-20f)
     {
@@ -731,8 +735,9 @@ compute_velocity_constraint_correction_settle(
     const float projection = dr * v_diff;
     if (constraint_violated != NULL)
     {
-        const float scale = sqrtf(dr2 * fmaxf(v_diff * v_diff, 1.0e-12f));
-        *constraint_violated = fabsf(projection) > relative_tolerance * scale;
+        const float tolerance = Velocity_Constraint_Residual_Tolerance(
+            dr2, velocity_i, velocity_j, v_diff, relative_tolerance);
+        *constraint_violated = fabsf(projection) > tolerance;
     }
     float lambda = projection / denom;
     correction_i[0] = (-mass_i_inverse * lambda) * dr;

--- a/SPONGE/constrain/settle.cpp
+++ b/SPONGE/constrain/settle.cpp
@@ -703,8 +703,10 @@ static __device__ __host__ __forceinline__ bool
 compute_velocity_constraint_correction_settle(
     const int atom_i, const int atom_j, const VECTOR* crd, const LTMatrix3 cell,
     const LTMatrix3 rcell, const float* mass_inverse, const VECTOR* vel,
-    VECTOR* correction_i, VECTOR* correction_j)
+    VECTOR* correction_i, VECTOR* correction_j, const float relative_tolerance,
+    bool* constraint_violated)
 {
+    if (constraint_violated != NULL) *constraint_violated = false;
     float mass_i_inverse = mass_inverse[atom_i];
     float mass_j_inverse = mass_inverse[atom_j];
     if (mass_i_inverse == 0.0f && mass_j_inverse == 0.0f) return false;
@@ -712,13 +714,27 @@ compute_velocity_constraint_correction_settle(
     VECTOR dr =
         Get_Periodic_Displacement(crd[atom_i], crd[atom_j], cell, rcell);
     float dr2 = dr * dr;
-    if (dr2 < 1e-12f) return false;
+    if (dr2 < 1e-12f)
+    {
+        if (constraint_violated != NULL) *constraint_violated = true;
+        return false;
+    }
 
     VECTOR v_diff = vel[atom_i] - vel[atom_j];
     float denom = (mass_i_inverse + mass_j_inverse) * dr2;
-    if (denom < 1e-20f) return false;
+    if (denom < 1e-20f)
+    {
+        if (constraint_violated != NULL) *constraint_violated = true;
+        return false;
+    }
 
-    float lambda = (dr * v_diff) / denom;
+    const float projection = dr * v_diff;
+    if (constraint_violated != NULL)
+    {
+        const float scale = sqrtf(dr2 * fmaxf(v_diff * v_diff, 1.0e-12f));
+        *constraint_violated = fabsf(projection) > relative_tolerance * scale;
+    }
+    float lambda = projection / denom;
     correction_i[0] = (-mass_i_inverse * lambda) * dr;
     correction_j[0] = (mass_j_inverse * lambda) * dr;
     return true;
@@ -727,7 +743,8 @@ compute_velocity_constraint_correction_settle(
 static __global__ void project_velocity_to_settle_pairs(
     const int pair_numbers, const CONSTRAIN_PAIR* pairs, const VECTOR* crd,
     const LTMatrix3 cell, const LTMatrix3 rcell, const float* mass_inverse,
-    const VECTOR* vel, VECTOR* delta_vel)
+    const VECTOR* vel, VECTOR* delta_vel, const float relative_tolerance,
+    int* violation)
 {
 #ifdef USE_GPU
     int pair_i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -739,9 +756,12 @@ static __global__ void project_velocity_to_settle_pairs(
     {
         CONSTRAIN_PAIR cp = pairs[pair_i];
         VECTOR correction_i, correction_j;
+        bool constraint_violated = false;
         if (compute_velocity_constraint_correction_settle(
                 cp.atom_i_serial, cp.atom_j_serial, crd, cell, rcell,
-                mass_inverse, vel, &correction_i, &correction_j))
+                mass_inverse, vel, &correction_i, &correction_j,
+                relative_tolerance,
+                violation != NULL ? &constraint_violated : NULL))
         {
             atomicAdd(&delta_vel[cp.atom_i_serial].x, correction_i.x);
             atomicAdd(&delta_vel[cp.atom_i_serial].y, correction_i.y);
@@ -750,13 +770,15 @@ static __global__ void project_velocity_to_settle_pairs(
             atomicAdd(&delta_vel[cp.atom_j_serial].y, correction_j.y);
             atomicAdd(&delta_vel[cp.atom_j_serial].z, correction_j.z);
         }
+        if (constraint_violated && violation != NULL) atomicExch(violation, 1);
     }
 }
 
 static __global__ void project_velocity_to_settle_triangles(
     const int triangle_numbers, const CONSTRAIN_TRIANGLE* triangles,
     const VECTOR* crd, const LTMatrix3 cell, const LTMatrix3 rcell,
-    const float* mass_inverse, const VECTOR* vel, VECTOR* delta_vel)
+    const float* mass_inverse, const VECTOR* vel, VECTOR* delta_vel,
+    const float relative_tolerance, int* violation)
 {
 #ifdef USE_GPU
     int tri_i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -768,9 +790,11 @@ static __global__ void project_velocity_to_settle_triangles(
     {
         CONSTRAIN_TRIANGLE tri = triangles[tri_i];
         VECTOR correction_i, correction_j;
+        bool constraint_violated = false;
         if (compute_velocity_constraint_correction_settle(
                 tri.atom_A, tri.atom_B, crd, cell, rcell, mass_inverse, vel,
-                &correction_i, &correction_j))
+                &correction_i, &correction_j, relative_tolerance,
+                violation != NULL ? &constraint_violated : NULL))
         {
             atomicAdd(&delta_vel[tri.atom_A].x, correction_i.x);
             atomicAdd(&delta_vel[tri.atom_A].y, correction_i.y);
@@ -779,9 +803,11 @@ static __global__ void project_velocity_to_settle_triangles(
             atomicAdd(&delta_vel[tri.atom_B].y, correction_j.y);
             atomicAdd(&delta_vel[tri.atom_B].z, correction_j.z);
         }
+        if (constraint_violated && violation != NULL) atomicExch(violation, 1);
         if (compute_velocity_constraint_correction_settle(
                 tri.atom_A, tri.atom_C, crd, cell, rcell, mass_inverse, vel,
-                &correction_i, &correction_j))
+                &correction_i, &correction_j, relative_tolerance,
+                violation != NULL ? &constraint_violated : NULL))
         {
             atomicAdd(&delta_vel[tri.atom_A].x, correction_i.x);
             atomicAdd(&delta_vel[tri.atom_A].y, correction_i.y);
@@ -790,9 +816,11 @@ static __global__ void project_velocity_to_settle_triangles(
             atomicAdd(&delta_vel[tri.atom_C].y, correction_j.y);
             atomicAdd(&delta_vel[tri.atom_C].z, correction_j.z);
         }
+        if (constraint_violated && violation != NULL) atomicExch(violation, 1);
         if (compute_velocity_constraint_correction_settle(
                 tri.atom_B, tri.atom_C, crd, cell, rcell, mass_inverse, vel,
-                &correction_i, &correction_j))
+                &correction_i, &correction_j, relative_tolerance,
+                violation != NULL ? &constraint_violated : NULL))
         {
             atomicAdd(&delta_vel[tri.atom_B].x, correction_i.x);
             atomicAdd(&delta_vel[tri.atom_B].y, correction_i.y);
@@ -801,12 +829,14 @@ static __global__ void project_velocity_to_settle_triangles(
             atomicAdd(&delta_vel[tri.atom_C].y, correction_j.y);
             atomicAdd(&delta_vel[tri.atom_C].z, correction_j.z);
         }
+        if (constraint_violated && violation != NULL) atomicExch(violation, 1);
     }
 }
 
 static __global__ void apply_settle_velocity_correction(
     const int local_atom_numbers, VECTOR* vel, VECTOR* crd,
-    const VECTOR* delta_vel, const float half_dt)
+    const VECTOR* delta_vel, const float velocity_factor,
+    const float coordinate_factor)
 {
 #ifdef USE_GPU
     int atom_i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -816,24 +846,48 @@ static __global__ void apply_settle_velocity_correction(
     for (int atom_i = 0; atom_i < local_atom_numbers; atom_i++)
 #endif
     {
-        VECTOR delta = delta_vel[atom_i];
+        VECTOR delta = velocity_factor * delta_vel[atom_i];
         vel[atom_i] = vel[atom_i] + delta;
-        crd[atom_i] = crd[atom_i] + half_dt * delta;
+        if (coordinate_factor != 0.0f)
+        {
+            crd[atom_i] = crd[atom_i] + coordinate_factor * delta;
+        }
     }
 }
 
-void SETTLE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
+bool SETTLE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
                                                      const float* mass_inverse,
                                                      const LTMatrix3 cell,
-                                                     const LTMatrix3 rcell)
+                                                     const LTMatrix3 rcell,
+                                                     bool update_coordinates)
 {
-    if (!is_initialized || local_atom_numbers <= 0) return;
+    if (!is_initialized || local_atom_numbers <= 0) return true;
     bool has_settle_constraints = num_triangle_local > 0 || num_pair_local > 0;
-    if (!has_settle_constraints) return;
+    if (!has_settle_constraints) return true;
 
-    constexpr int projection_iterations = 8;
+    constexpr int legacy_projection_iterations = 8;
+    constexpr int maximum_velocity_only_iterations = 512;
+    constexpr float relative_tolerance = 1.0e-5f;
+    const int projection_iterations = update_coordinates
+                                          ? legacy_projection_iterations
+                                          : maximum_velocity_only_iterations;
+    // SETTLE extracts disjoint pairs and triangles.  A pair can be projected
+    // directly; a triangle has local constraint degree two, so damping its
+    // parallel Jacobi update by one half is sufficient and does not couple
+    // convergence to unrelated constraints left for SHAKE.
+    const int settle_constraint_degree = num_triangle_local > 0 ? 2 : 1;
+    const float velocity_factor =
+        update_coordinates
+            ? 1.0f
+            : 1.0f / static_cast<float>(settle_constraint_degree);
+    int* d_violation = NULL;
+    if (!update_coordinates &&
+        !Device_Malloc_Safely((void**)&d_violation, sizeof(int)))
+        return false;
+    bool converged = update_coordinates;
     for (int iter = 0; iter < projection_iterations; ++iter)
     {
+        if (!update_coordinates) deviceMemset(d_violation, 0, sizeof(int));
         deviceMemset(d_delta_vel_local, 0, sizeof(VECTOR) * local_atom_numbers);
         if (num_pair_local > 0 && d_pairs_local != NULL)
         {
@@ -843,7 +897,7 @@ void SETTLE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
                     CONTROLLER::device_max_thread,
                 CONTROLLER::device_max_thread, 0, NULL, num_pair_local,
                 d_pairs_local, crd, cell, rcell, mass_inverse, vel,
-                d_delta_vel_local);
+                d_delta_vel_local, relative_tolerance, d_violation);
         }
         if (num_triangle_local > 0 && d_triangles_local != NULL)
         {
@@ -853,15 +907,29 @@ void SETTLE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
                     CONTROLLER::device_max_thread,
                 CONTROLLER::device_max_thread, 0, NULL, num_triangle_local,
                 d_triangles_local, crd, cell, rcell, mass_inverse, vel,
-                d_delta_vel_local);
+                d_delta_vel_local, relative_tolerance, d_violation);
+        }
+        if (!update_coordinates)
+        {
+            int violation = 0;
+            deviceMemcpy(&violation, d_violation, sizeof(int),
+                         deviceMemcpyDeviceToHost);
+            if (violation == 0)
+            {
+                converged = true;
+                break;
+            }
         }
         Launch_Device_Kernel(
             apply_settle_velocity_correction,
             (local_atom_numbers + CONTROLLER::device_max_thread - 1) /
                 CONTROLLER::device_max_thread,
             CONTROLLER::device_max_thread, 0, NULL, local_atom_numbers, vel,
-            crd, d_delta_vel_local, 0.5f * constrain->dt);
+            crd, d_delta_vel_local, velocity_factor,
+            update_coordinates ? 0.5f * constrain->dt : 0.0f);
     }
+    if (d_violation != NULL) deviceFree(d_violation);
+    return converged;
 }
 
 void SETTLE::update_ug_connectivity(CONECT* connectivity)

--- a/SPONGE/constrain/settle.h
+++ b/SPONGE/constrain/settle.h
@@ -43,10 +43,10 @@ struct SETTLE
     void Do_SETTLE(const float* d_mass, VECTOR* crd, const LTMatrix3 cell,
                    const LTMatrix3 rcell, VECTOR* vel, const int need_pressure,
                    LTMatrix3* d_stress);
-    void Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
-                                                 const float* mass_inverse,
-                                                 const LTMatrix3 cell,
-                                                 const LTMatrix3 rcell);
+    bool Project_Velocity_To_Constraint_Manifold(
+        VECTOR* vel, VECTOR* crd, const float* mass_inverse,
+        const LTMatrix3 cell, const LTMatrix3 rcell,
+        bool update_coordinates = true);
 
     int local_atom_numbers = 0;
     int num_triangle_local = 0;

--- a/SPONGE/constrain/shake.cpp
+++ b/SPONGE/constrain/shake.cpp
@@ -198,8 +198,10 @@ static __device__ __host__ __forceinline__ bool
 compute_velocity_constraint_correction_shake(
     const int atom_i, const int atom_j, const VECTOR* crd, const LTMatrix3 cell,
     const LTMatrix3 rcell, const float* mass_inverse, const VECTOR* vel,
-    VECTOR* correction_i, VECTOR* correction_j)
+    VECTOR* correction_i, VECTOR* correction_j, const float relative_tolerance,
+    bool* constraint_violated)
 {
+    if (constraint_violated != NULL) *constraint_violated = false;
     float mass_i_inverse = mass_inverse[atom_i];
     float mass_j_inverse = mass_inverse[atom_j];
     if (mass_i_inverse == 0.0f && mass_j_inverse == 0.0f) return false;
@@ -207,13 +209,27 @@ compute_velocity_constraint_correction_shake(
     VECTOR dr =
         Get_Periodic_Displacement(crd[atom_i], crd[atom_j], cell, rcell);
     float dr2 = dr * dr;
-    if (dr2 < 1e-12f) return false;
+    if (dr2 < 1e-12f)
+    {
+        if (constraint_violated != NULL) *constraint_violated = true;
+        return false;
+    }
 
     VECTOR v_diff = vel[atom_i] - vel[atom_j];
     float denom = (mass_i_inverse + mass_j_inverse) * dr2;
-    if (denom < 1e-20f) return false;
+    if (denom < 1e-20f)
+    {
+        if (constraint_violated != NULL) *constraint_violated = true;
+        return false;
+    }
 
-    float lambda = (dr * v_diff) / denom;
+    const float projection = dr * v_diff;
+    if (constraint_violated != NULL)
+    {
+        const float scale = sqrtf(dr2 * fmaxf(v_diff * v_diff, 1.0e-12f));
+        *constraint_violated = fabsf(projection) > relative_tolerance * scale;
+    }
+    float lambda = projection / denom;
     correction_i[0] = (-mass_i_inverse * lambda) * dr;
     correction_j[0] = (mass_j_inverse * lambda) * dr;
     return true;
@@ -222,7 +238,8 @@ compute_velocity_constraint_correction_shake(
 static __global__ void project_velocity_to_shake_pairs(
     const int pair_numbers, const CONSTRAIN_PAIR* pairs, const VECTOR* crd,
     const LTMatrix3 cell, const LTMatrix3 rcell, const float* mass_inverse,
-    const VECTOR* vel, VECTOR* delta_vel)
+    const VECTOR* vel, VECTOR* delta_vel, const float relative_tolerance,
+    int* violation)
 {
 #ifdef USE_GPU
     int pair_i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -234,9 +251,12 @@ static __global__ void project_velocity_to_shake_pairs(
     {
         CONSTRAIN_PAIR cp = pairs[pair_i];
         VECTOR correction_i, correction_j;
+        bool constraint_violated = false;
         if (compute_velocity_constraint_correction_shake(
                 cp.atom_i_serial, cp.atom_j_serial, crd, cell, rcell,
-                mass_inverse, vel, &correction_i, &correction_j))
+                mass_inverse, vel, &correction_i, &correction_j,
+                relative_tolerance,
+                violation != NULL ? &constraint_violated : NULL))
         {
             atomicAdd(&delta_vel[cp.atom_i_serial].x, correction_i.x);
             atomicAdd(&delta_vel[cp.atom_i_serial].y, correction_i.y);
@@ -245,12 +265,14 @@ static __global__ void project_velocity_to_shake_pairs(
             atomicAdd(&delta_vel[cp.atom_j_serial].y, correction_j.y);
             atomicAdd(&delta_vel[cp.atom_j_serial].z, correction_j.z);
         }
+        if (constraint_violated && violation != NULL) atomicExch(violation, 1);
     }
 }
 
 static __global__ void apply_shake_velocity_correction(
     const int local_atom_numbers, VECTOR* vel, VECTOR* crd,
-    const VECTOR* delta_vel, const float half_dt)
+    const VECTOR* delta_vel, const float velocity_factor,
+    const float coordinate_factor)
 {
 #ifdef USE_GPU
     int atom_i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -260,25 +282,46 @@ static __global__ void apply_shake_velocity_correction(
     for (int atom_i = 0; atom_i < local_atom_numbers; atom_i++)
 #endif
     {
-        VECTOR delta = delta_vel[atom_i];
+        VECTOR delta = velocity_factor * delta_vel[atom_i];
         vel[atom_i] = vel[atom_i] + delta;
-        crd[atom_i] = crd[atom_i] + half_dt * delta;
+        if (coordinate_factor != 0.0f)
+        {
+            crd[atom_i] = crd[atom_i] + coordinate_factor * delta;
+        }
     }
 }
 
-void SHAKE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
-                                                    const float* mass_inverse,
-                                                    const LTMatrix3 cell,
-                                                    const LTMatrix3 rcell,
-                                                    int local_atom_numbers)
+bool SHAKE::Project_Velocity_To_Constraint_Manifold(
+    VECTOR* vel, VECTOR* crd, const float* mass_inverse, const LTMatrix3 cell,
+    const LTMatrix3 rcell, int local_atom_numbers, bool update_coordinates)
 {
     if (!is_initialized || local_atom_numbers <= 0 ||
         constrain->num_pair_local <= 0)
-        return;
+        return true;
 
-    constexpr int projection_iterations = 8;
+    constexpr int legacy_projection_iterations = 8;
+    constexpr int maximum_velocity_only_iterations = 512;
+    constexpr float relative_tolerance = 1.0e-5f;
+    const int projection_iterations = update_coordinates
+                                          ? legacy_projection_iterations
+                                          : maximum_velocity_only_iterations;
+    // A constraint row overlaps at most 2(d - 1) other rows, so the normalized
+    // pair-overlap matrix has lambda_max <= 2d - 1.  Damping by 1/d therefore
+    // keeps the parallel Richardson/Jacobi update stable.  The degree was
+    // measured before SETTLE pairs were removed, so it is conservative here.
+    const float velocity_factor =
+        update_coordinates
+            ? 1.0f
+            : 1.0f / static_cast<float>(
+                         std::max(1, constrain->maximum_constraint_degree));
+    int* d_violation = NULL;
+    if (!update_coordinates &&
+        !Device_Malloc_Safely((void**)&d_violation, sizeof(int)))
+        return false;
+    bool converged = update_coordinates;
     for (int iter = 0; iter < projection_iterations; ++iter)
     {
+        if (!update_coordinates) deviceMemset(d_violation, 0, sizeof(int));
         deviceMemset(constrain_frc, 0, sizeof(VECTOR) * local_atom_numbers);
         Launch_Device_Kernel(
             project_velocity_to_shake_pairs,
@@ -286,14 +329,28 @@ void SHAKE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
                 CONTROLLER::device_max_thread,
             CONTROLLER::device_max_thread, 0, NULL, constrain->num_pair_local,
             constrain->constrain_pair_local, crd, cell, rcell, mass_inverse,
-            vel, constrain_frc);
+            vel, constrain_frc, relative_tolerance, d_violation);
+        if (!update_coordinates)
+        {
+            int violation = 0;
+            deviceMemcpy(&violation, d_violation, sizeof(int),
+                         deviceMemcpyDeviceToHost);
+            if (violation == 0)
+            {
+                converged = true;
+                break;
+            }
+        }
         Launch_Device_Kernel(
             apply_shake_velocity_correction,
             (local_atom_numbers + CONTROLLER::device_max_thread - 1) /
                 CONTROLLER::device_max_thread,
             CONTROLLER::device_max_thread, 0, NULL, local_atom_numbers, vel,
-            crd, constrain_frc, 0.5f * constrain->dt);
+            crd, constrain_frc, velocity_factor,
+            update_coordinates ? 0.5f * constrain->dt : 0.0f);
     }
+    if (d_violation != NULL) deviceFree(d_violation);
+    return converged;
 }
 
 static __global__ void Constrain_Force_Cycle_With_Virial(

--- a/SPONGE/constrain/shake.cpp
+++ b/SPONGE/constrain/shake.cpp
@@ -1,5 +1,7 @@
 ﻿#include "shake.h"
 
+#include "velocity_projection.h"
+
 static __global__ void Constrain_Force_Cycle(
     const int constrain_pair_numbers, const VECTOR* crd, const LTMatrix3 cell,
     const LTMatrix3 rcell, const CONSTRAIN_PAIR* constrain_pair,
@@ -215,7 +217,9 @@ compute_velocity_constraint_correction_shake(
         return false;
     }
 
-    VECTOR v_diff = vel[atom_i] - vel[atom_j];
+    const VECTOR velocity_i = vel[atom_i];
+    const VECTOR velocity_j = vel[atom_j];
+    VECTOR v_diff = velocity_i - velocity_j;
     float denom = (mass_i_inverse + mass_j_inverse) * dr2;
     if (denom < 1e-20f)
     {
@@ -226,8 +230,9 @@ compute_velocity_constraint_correction_shake(
     const float projection = dr * v_diff;
     if (constraint_violated != NULL)
     {
-        const float scale = sqrtf(dr2 * fmaxf(v_diff * v_diff, 1.0e-12f));
-        *constraint_violated = fabsf(projection) > relative_tolerance * scale;
+        const float tolerance = Velocity_Constraint_Residual_Tolerance(
+            dr2, velocity_i, velocity_j, v_diff, relative_tolerance);
+        *constraint_violated = fabsf(projection) > tolerance;
     }
     float lambda = projection / denom;
     correction_i[0] = (-mass_i_inverse * lambda) * dr;

--- a/SPONGE/constrain/shake.h
+++ b/SPONGE/constrain/shake.h
@@ -36,11 +36,10 @@ struct SHAKE
     void Remember_Last_Coordinates(const VECTOR* crd, const LTMatrix3 cell,
                                    const LTMatrix3 rcell);
     // 将速度投影到SHAKE约束流形
-    void Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
-                                                 const float* mass_inverse,
-                                                 const LTMatrix3 cell,
-                                                 const LTMatrix3 rcell,
-                                                 int local_atom_numbers);
+    bool Project_Velocity_To_Constraint_Manifold(
+        VECTOR* vel, VECTOR* crd, const float* mass_inverse,
+        const LTMatrix3 cell, const LTMatrix3 rcell, int local_atom_numbers,
+        bool update_coordinates = true);
     // 进行约束迭代
     void Constrain(int atom_numbers, VECTOR* crd, VECTOR* vel,
                    const float* mass_inverse, const float* d_mass,

--- a/SPONGE/constrain/velocity_projection.h
+++ b/SPONGE/constrain/velocity_projection.h
@@ -1,0 +1,26 @@
+﻿#pragma once
+
+#include <cfloat>
+
+#include "../common.h"
+
+// A relative residual alone is unattainable when two stored float velocities
+// are nearly equal.  Bound the subtraction and three-component dot-product
+// roundoff by the scale of the operands that are actually represented.
+static __device__ __host__ __forceinline__ float
+Velocity_Constraint_Residual_Tolerance(const float displacement_squared,
+                                       const VECTOR velocity_i,
+                                       const VECTOR velocity_j,
+                                       const VECTOR velocity_difference,
+                                       const float relative_tolerance)
+{
+    const float displacement_norm = sqrtf(displacement_squared);
+    const float relative_scale =
+        displacement_norm *
+        sqrtf(fmaxf(velocity_difference * velocity_difference, 1.0e-12f));
+    const float velocity_scale =
+        fmaxf(sqrtf(velocity_i * velocity_i), sqrtf(velocity_j * velocity_j));
+    const float roundoff_floor =
+        8.0f * FLT_EPSILON * displacement_norm * velocity_scale;
+    return fmaxf(relative_tolerance * relative_scale, roundoff_floor);
+}

--- a/benchmarks/validation/misc/tests/constraint_velocity_projection_probe.cpp
+++ b/benchmarks/validation/misc/tests/constraint_velocity_projection_probe.cpp
@@ -1,4 +1,5 @@
-﻿#include <cmath>
+﻿#include <cfloat>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 
@@ -25,6 +26,19 @@ const VECTOR kVelocities[kAtomCount] = {
 };
 const float kMassInverse[kAtomCount] = {1.0f / 16.0f, 1.0f, 1.0f};
 const int kPairs[kPairCount][2] = {{0, 1}, {0, 2}, {1, 2}};
+
+const VECTOR kRoundoffCoordinates[kAtomCount] = {
+    {0.0f, 0.0f, 0.0f},
+    {0.5699996948242188f, 0.779998779296875f, -0.25f},
+    {-0.5999984741210938f, 0.26000213623046875f, 0.7599983215332031f},
+};
+const VECTOR kRoundoffVelocities[kAtomCount] = {
+    {-0.174088716506958f, -0.10837503522634506f, 0.24693767726421356f},
+    {-1.4800273180007935f, 1.8255033493041992f, 0.039367739111185074f},
+    {-0.05815054848790169f, 1.55351984500885f, -1.609876275062561f},
+};
+const float kRoundoffMassInverse[kAtomCount] = {1.0f / 15.9994f, 1.0f / 1.008f,
+                                                1.0f / 1.008f};
 
 bool Fail(const char* message)
 {
@@ -70,6 +84,50 @@ bool Check_Velocity_Only_Result(const char* name,
     return true;
 }
 
+bool Check_Roundoff_Floor_Result(const char* name,
+                                 const VECTOR* original_coordinates,
+                                 const VECTOR* projected_coordinates,
+                                 const VECTOR* projected_velocities)
+{
+    if (std::memcmp(original_coordinates, projected_coordinates,
+                    sizeof(kRoundoffCoordinates)) != 0)
+        return Fail("roundoff-floor projection changed coordinates");
+
+    bool exercised_roundoff_floor = false;
+    for (const auto& pair : kPairs)
+    {
+        const VECTOR displacement =
+            projected_coordinates[pair[0]] - projected_coordinates[pair[1]];
+        const VECTOR velocity_i = projected_velocities[pair[0]];
+        const VECTOR velocity_j = projected_velocities[pair[1]];
+        const VECTOR velocity_difference = velocity_i - velocity_j;
+        const float displacement_squared = displacement * displacement;
+        const float projection = displacement * velocity_difference;
+        const float relative_scale =
+            sqrtf(displacement_squared *
+                  fmaxf(velocity_difference * velocity_difference, 1.0e-12f));
+        const float relative_limit = 1.0e-5f * relative_scale;
+        const float velocity_scale = fmaxf(sqrtf(velocity_i * velocity_i),
+                                           sqrtf(velocity_j * velocity_j));
+        const float roundoff_floor =
+            8.0f * FLT_EPSILON * sqrtf(displacement_squared) * velocity_scale;
+        const float tolerance = fmaxf(relative_limit, roundoff_floor);
+        if (!std::isfinite(projection) || !std::isfinite(tolerance) ||
+            std::fabs(projection) > tolerance)
+        {
+            std::fprintf(stderr,
+                         "%s residual %.9g exceeds attainable tolerance %.9g\n",
+                         name, static_cast<double>(std::fabs(projection)),
+                         static_cast<double>(tolerance));
+            return false;
+        }
+        exercised_roundoff_floor |= std::fabs(projection) > relative_limit &&
+                                    roundoff_floor > relative_limit;
+    }
+    return exercised_roundoff_floor ||
+           Fail("roundoff-floor case did not exercise the float bound");
+}
+
 bool Check_Settle()
 {
     CONSTRAIN constrain;
@@ -103,6 +161,16 @@ bool Check_Settle()
         return Fail("SETTLE velocity-only projection did not converge");
     if (!Check_Velocity_Only_Result("SETTLE", kCoordinates, coordinates,
                                     velocities))
+        return false;
+
+    std::memcpy(coordinates, kRoundoffCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kRoundoffVelocities, sizeof(velocities));
+    if (!settle.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kRoundoffMassInverse, direct_space,
+            direct_space, false))
+        return Fail("SETTLE rejected a float-limited attainable projection");
+    if (!Check_Roundoff_Floor_Result("SETTLE", kRoundoffCoordinates,
+                                     coordinates, velocities))
         return false;
 
     std::memcpy(coordinates, kCoordinates, sizeof(coordinates));
@@ -145,6 +213,16 @@ bool Check_Shake()
         return Fail("SHAKE velocity-only projection did not converge");
     if (!Check_Velocity_Only_Result("SHAKE", kCoordinates, coordinates,
                                     velocities))
+        return false;
+
+    std::memcpy(coordinates, kRoundoffCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kRoundoffVelocities, sizeof(velocities));
+    if (!shake.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kRoundoffMassInverse, direct_space,
+            direct_space, kAtomCount, false))
+        return Fail("SHAKE rejected a float-limited attainable projection");
+    if (!Check_Roundoff_Floor_Result("SHAKE", kRoundoffCoordinates, coordinates,
+                                     velocities))
         return false;
 
     std::memcpy(coordinates, kCoordinates, sizeof(coordinates));

--- a/benchmarks/validation/misc/tests/constraint_velocity_projection_probe.cpp
+++ b/benchmarks/validation/misc/tests/constraint_velocity_projection_probe.cpp
@@ -1,0 +1,219 @@
+﻿#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+#include "constrain/settle.h"
+#include "constrain/shake.h"
+
+unsigned int CONTROLLER::device_max_thread = 64;
+
+namespace
+{
+
+constexpr int kAtomCount = 3;
+constexpr int kPairCount = 3;
+
+const VECTOR kCoordinates[kAtomCount] = {
+    {0.0f, 0.0f, 0.0f},
+    {0.8233542f, -0.0292778f, 0.4872141f},
+    {-0.6461200f, -0.3741645f, 0.5988970f},
+};
+const VECTOR kVelocities[kAtomCount] = {
+    {0.3f, -0.2f, 0.4f},
+    {-0.7f, 0.5f, 0.1f},
+    {0.8f, 0.9f, -0.3f},
+};
+const float kMassInverse[kAtomCount] = {1.0f / 16.0f, 1.0f, 1.0f};
+const int kPairs[kPairCount][2] = {{0, 1}, {0, 2}, {1, 2}};
+
+bool Fail(const char* message)
+{
+    std::fprintf(stderr, "%s\n", message);
+    return false;
+}
+
+float Maximum_Relative_Residual(const VECTOR* coordinates,
+                                const VECTOR* velocities)
+{
+    float maximum = 0.0f;
+    for (const auto& pair : kPairs)
+    {
+        const VECTOR displacement = coordinates[pair[0]] - coordinates[pair[1]];
+        const VECTOR velocity_difference =
+            velocities[pair[0]] - velocities[pair[1]];
+        const float numerator = std::fabs(displacement * velocity_difference);
+        const float denominator =
+            std::sqrt((displacement * displacement) *
+                      (velocity_difference * velocity_difference));
+        maximum =
+            std::fmax(maximum, numerator / std::fmax(denominator, 1e-12f));
+    }
+    return maximum;
+}
+
+bool Check_Velocity_Only_Result(const char* name,
+                                const VECTOR* original_coordinates,
+                                const VECTOR* projected_coordinates,
+                                const VECTOR* projected_velocities)
+{
+    if (std::memcmp(original_coordinates, projected_coordinates,
+                    sizeof(kCoordinates)) != 0)
+        return Fail("velocity-only projection changed coordinates");
+    const float residual =
+        Maximum_Relative_Residual(projected_coordinates, projected_velocities);
+    if (!std::isfinite(residual) || residual > 2e-5f)
+    {
+        std::fprintf(stderr, "%s residual %.9g exceeds tolerance\n", name,
+                     static_cast<double>(residual));
+        return false;
+    }
+    return true;
+}
+
+bool Check_Settle()
+{
+    CONSTRAIN constrain;
+    constrain.dt = 0.002f;
+    // An unrelated high-degree SHAKE component must not reduce the SETTLE
+    // projection step or make an otherwise valid water fail to converge.
+    constrain.maximum_constraint_degree = 1024;
+
+    CONSTRAIN_TRIANGLE triangle = {};
+    triangle.atom_A = 0;
+    triangle.atom_B = 1;
+    triangle.atom_C = 2;
+    VECTOR delta_velocity[kAtomCount] = {};
+
+    SETTLE settle;
+    settle.is_initialized = 1;
+    settle.constrain = &constrain;
+    settle.local_atom_numbers = kAtomCount;
+    settle.num_triangle_local = 1;
+    settle.d_triangles_local = &triangle;
+    settle.d_delta_vel_local = delta_velocity;
+
+    VECTOR coordinates[kAtomCount];
+    VECTOR velocities[kAtomCount];
+    std::memcpy(coordinates, kCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kVelocities, sizeof(velocities));
+    const LTMatrix3 direct_space;
+    if (!settle.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kMassInverse, direct_space, direct_space,
+            false))
+        return Fail("SETTLE velocity-only projection did not converge");
+    if (!Check_Velocity_Only_Result("SETTLE", kCoordinates, coordinates,
+                                    velocities))
+        return false;
+
+    std::memcpy(coordinates, kCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kVelocities, sizeof(velocities));
+    if (!settle.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kMassInverse, direct_space, direct_space))
+        return Fail("SETTLE default projection reported failure");
+    return std::memcmp(kCoordinates, coordinates, sizeof(coordinates)) != 0 ||
+           Fail("SETTLE default projection no longer updates coordinates");
+}
+
+bool Check_Shake()
+{
+    CONSTRAIN constrain;
+    constrain.dt = 0.002f;
+    constrain.maximum_constraint_degree = 2;
+    CONSTRAIN_PAIR pairs[kPairCount] = {};
+    for (int index = 0; index < kPairCount; ++index)
+    {
+        pairs[index].atom_i_serial = kPairs[index][0];
+        pairs[index].atom_j_serial = kPairs[index][1];
+    }
+    constrain.num_pair_local = kPairCount;
+    constrain.constrain_pair_local = pairs;
+
+    VECTOR correction[kAtomCount] = {};
+    SHAKE shake;
+    shake.is_initialized = 1;
+    shake.constrain = &constrain;
+    shake.constrain_frc = correction;
+
+    VECTOR coordinates[kAtomCount];
+    VECTOR velocities[kAtomCount];
+    std::memcpy(coordinates, kCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kVelocities, sizeof(velocities));
+    const LTMatrix3 direct_space;
+    if (!shake.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kMassInverse, direct_space, direct_space,
+            kAtomCount, false))
+        return Fail("SHAKE velocity-only projection did not converge");
+    if (!Check_Velocity_Only_Result("SHAKE", kCoordinates, coordinates,
+                                    velocities))
+        return false;
+
+    std::memcpy(coordinates, kCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kVelocities, sizeof(velocities));
+    if (!shake.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kMassInverse, direct_space, direct_space,
+            kAtomCount))
+        return Fail("SHAKE default projection reported failure");
+    return std::memcmp(kCoordinates, coordinates, sizeof(coordinates)) != 0 ||
+           Fail("SHAKE default projection no longer updates coordinates");
+}
+
+bool Check_Degenerate_Constraint_Status()
+{
+    CONSTRAIN constrain;
+    constrain.dt = 0.002f;
+    constrain.maximum_constraint_degree = 1;
+
+    CONSTRAIN_PAIR pair = {};
+    pair.atom_i_serial = 0;
+    pair.atom_j_serial = 1;
+    constrain.num_pair_local = 1;
+    constrain.constrain_pair_local = &pair;
+
+    VECTOR coordinates[2] = {};
+    VECTOR velocities[2] = {VECTOR(1.0f, 0.0f, 0.0f),
+                            VECTOR(-1.0f, 0.0f, 0.0f)};
+    const float dynamic_mass_inverse[2] = {1.0f, 1.0f};
+    const float fixed_mass_inverse[2] = {0.0f, 0.0f};
+    VECTOR correction[2] = {};
+    const LTMatrix3 direct_space;
+
+    SETTLE settle;
+    settle.is_initialized = 1;
+    settle.constrain = &constrain;
+    settle.local_atom_numbers = 2;
+    settle.num_pair_local = 1;
+    settle.d_pairs_local = &pair;
+    settle.d_delta_vel_local = correction;
+    if (settle.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, dynamic_mass_inverse, direct_space,
+            direct_space, false))
+        return Fail("SETTLE accepted a degenerate dynamic constraint");
+    if (!settle.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, fixed_mass_inverse, direct_space,
+            direct_space, false))
+        return Fail("SETTLE rejected an all-fixed constraint");
+
+    SHAKE shake;
+    shake.is_initialized = 1;
+    shake.constrain = &constrain;
+    shake.constrain_frc = correction;
+    if (shake.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, dynamic_mass_inverse, direct_space,
+            direct_space, 2, false))
+        return Fail("SHAKE accepted a degenerate dynamic constraint");
+    if (!shake.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, fixed_mass_inverse, direct_space,
+            direct_space, 2, false))
+        return Fail("SHAKE rejected an all-fixed constraint");
+    return true;
+}
+
+}  // namespace
+
+int main()
+{
+    return Check_Settle() && Check_Shake() &&
+                   Check_Degenerate_Constraint_Status()
+               ? 0
+               : 1;
+}

--- a/benchmarks/validation/misc/tests/test_constraint_velocity_projection.py
+++ b/benchmarks/validation/misc/tests/test_constraint_velocity_projection.py
@@ -1,0 +1,93 @@
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+PROBE_SOURCE = Path(__file__).with_name(
+    "constraint_velocity_projection_probe.cpp"
+)
+
+
+def _compiler_command():
+    configured = os.environ.get("CXX")
+    if configured:
+        return shlex.split(configured)
+    if sys.platform == "darwin" and Path("/usr/bin/clang++").is_file():
+        return ["/usr/bin/clang++"]
+    compiler = (
+        shutil.which("c++") or shutil.which("clang++") or shutil.which("g++")
+    )
+    if compiler is None:
+        pytest.skip("a C++17 compiler is required for the constraint probe")
+    return [compiler]
+
+
+def _dependency_include():
+    candidates = []
+    if os.environ.get("CONDA_PREFIX"):
+        candidates.append(Path(os.environ["CONDA_PREFIX"]) / "include")
+    candidates.append(
+        REPOSITORY_ROOT / ".pixi" / "envs" / "dev-cpu" / "include"
+    )
+    for candidate in candidates:
+        if (candidate / "omp.h").is_file() and (
+            candidate / "fftw3.h"
+        ).is_file():
+            return candidate
+    pytest.skip("OpenMP and FFTW headers are required for the constraint probe")
+
+
+def test_velocity_only_constraint_projection_converges_without_moving_crd(
+    tmp_path,
+):
+    executable = tmp_path / "constraint_velocity_projection_probe"
+    dead_code_flags = (
+        ["-Wl,-dead_strip"]
+        if sys.platform == "darwin"
+        else ["-Wl,--gc-sections"]
+    )
+    compile_result = subprocess.run(
+        [
+            *_compiler_command(),
+            "-std=c++17",
+            "-DUSE_CPU",
+            "-DNO_GLOBAL_CONTROLLER",
+            "-O3",
+            "-march=native",
+            "-ffast-math",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-w",
+            f"-I{REPOSITORY_ROOT / 'SPONGE'}",
+            f"-I{_dependency_include()}",
+            str(PROBE_SOURCE),
+            str(REPOSITORY_ROOT / "SPONGE/constrain/settle.cpp"),
+            str(REPOSITORY_ROOT / "SPONGE/constrain/shake.cpp"),
+            str(REPOSITORY_ROOT / "SPONGE/common.cpp"),
+            *dead_code_flags,
+            "-o",
+            str(executable),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+    assert compile_result.returncode == 0, (
+        "failed to compile constraint projection probe\n"
+        f"stdout:\n{compile_result.stdout}\nstderr:\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run(
+        [str(executable)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr


### PR DESCRIPTION
### 问题

原判定使用纯相对容差：`fabsf(projection) > relative_tolerance * sqrtf(dr2 * |v_diff|²)`。当两个存储为 float 的速度几乎相等时，`v_diff` 的相对误差被减法抵消放大，纯相对容差在 float 精度下不可达，导致合法状态被误判为 constraint violated。

### 方案

- 新增 `constrain/velocity_projection.h`：容差改为相对项 + 舍入下限（8·FLT_EPSILON 量级，覆盖减法与三分量点积的浮点误差界）
- 速度投影采用阻尼 Jacobi/Richardson 迭代，阻尼因子取 `1/maximum_constraint_degree`（谱半径上界 λmax ≤ 2d−1，保证收敛），迭代上限 512 次
- 默认路径行为逐位不变：`velocity_factor=1.0`、`coordinate_factor=0.5*dt` 与原式浮点等价；`violation==NULL` 时完全跳过容差计算，生产路径零开销