### PR TITLE
fix(gromacs): handle exclusions and reject unsupported sections

### DIFF
--- a/SPONGE/xponge/load/gromacs.hpp
+++ b/SPONGE/xponge/load/gromacs.hpp
@@ -164,6 +164,7 @@ struct Gromacs_Molecule
     std::vector<Gromacs_Dihedral> dihedrals;
     std::vector<Gromacs_Settle> settles;
     std::vector<Gromacs_Constraint> constraints;
+    std::set<std::pair<int, int>> exclusions;
     std::vector<Gromacs_CMap> cmaps;
 };
 
@@ -184,6 +185,13 @@ struct Gromacs_Topology
     std::vector<Gromacs_CMap_Type> cmap_types;
     std::unordered_map<std::string, Gromacs_Molecule> molecules;
     std::vector<std::pair<std::string, int>> system_molecules;
+};
+
+struct Gromacs_Source_Line
+{
+    std::string text;
+    fs::path file_path;
+    std::size_t line_number = 0;
 };
 
 static std::string Gromacs_Trim(const std::string& value)
@@ -279,7 +287,7 @@ static fs::path Gromacs_Resolve_Include(
 static void Gromacs_Preprocess_File(const fs::path& file_path,
                                     std::set<std::string>* macros,
                                     const std::vector<fs::path>& include_dirs,
-                                    std::vector<std::string>* lines,
+                                    std::vector<Gromacs_Source_Line>* lines,
                                     CONTROLLER* controller,
                                     const char* error_by)
 {
@@ -311,8 +319,11 @@ static void Gromacs_Preprocess_File(const fs::path& file_path,
 
     std::string raw_line;
     std::string continued_line;
+    std::size_t line_number = 0;
     while (std::getline(fin, raw_line))
     {
+        line_number++;
+        std::size_t logical_line_number = line_number;
         std::string line = Gromacs_Trim(raw_line);
         if (!line.empty() && line[0] == '#')
         {
@@ -425,6 +436,7 @@ static void Gromacs_Preprocess_File(const fs::path& file_path,
                     spongeErrorBadFileFormat, error_by,
                     "Reason:\n\tunterminated GROMACS line continuation\n");
             }
+            line_number++;
             std::string next_line =
                 Gromacs_Strip_Comment(Gromacs_Trim(raw_line));
             if (!next_line.empty())
@@ -435,7 +447,7 @@ static void Gromacs_Preprocess_File(const fs::path& file_path,
         }
         if (!continued_line.empty())
         {
-            lines->push_back(continued_line);
+            lines->push_back({continued_line, file_path, logical_line_number});
             continued_line.clear();
         }
     }
@@ -446,6 +458,23 @@ static void Gromacs_Preprocess_File(const fs::path& file_path,
             spongeErrorBadFileFormat, error_by,
             "Reason:\n\tunterminated GROMACS preprocessor conditional\n");
     }
+}
+
+static bool Gromacs_Is_Parsed_Section(const std::string& section)
+{
+    static const std::set<std::string> parsed_sections = {
+        "defaults",      "atomtypes", "bondtypes",      "angletypes",
+        "dihedraltypes", "pairtypes", "nonbond_params", "cmaptypes",
+        "moleculetype",  "atoms",     "bonds",          "pairs",
+        "angles",        "dihedrals", "settles",        "constraints",
+        "exclusions",    "cmap",      "molecules"};
+    return parsed_sections.count(section) > 0;
+}
+
+static bool Gromacs_Is_Ignored_Metadata_Section(const std::string& section)
+{
+    static const std::set<std::string> ignored_metadata_sections = {"system"};
+    return ignored_metadata_sections.count(section) > 0;
 }
 
 static float Gromacs_To_Kcal(float value_in_kj) { return value_in_kj / 4.184f; }
@@ -699,7 +728,7 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
         }
     }
 
-    std::vector<std::string> lines;
+    std::vector<Gromacs_Source_Line> lines;
     Gromacs_Preprocess_File(top_path, &macros, include_dirs, &lines, controller,
                             error_by);
 
@@ -707,11 +736,23 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
     std::string current_section;
     Gromacs_Molecule* current_molecule = NULL;
 
-    for (const std::string& line : lines)
+    for (const Gromacs_Source_Line& source_line : lines)
     {
+        const std::string& line = source_line.text;
         if (line.front() == '[' && line.back() == ']')
         {
             current_section = Gromacs_Trim(line.substr(1, line.size() - 2));
+            if (!Gromacs_Is_Parsed_Section(current_section) &&
+                !Gromacs_Is_Ignored_Metadata_Section(current_section))
+            {
+                std::string reason =
+                    "Reason:\n\tunsupported GROMACS topology section [ " +
+                    current_section + " ] at " +
+                    source_line.file_path.string() + ":" +
+                    std::to_string(source_line.line_number) + "\n";
+                controller->Throw_SPONGE_Error(spongeErrorBadFileFormat,
+                                               error_by, reason.c_str());
+            }
             continue;
         }
 
@@ -1078,6 +1119,33 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
             }
             current_molecule->constraints.push_back(constraint);
         }
+        else if (current_section == "exclusions")
+        {
+            if (current_molecule == NULL || tokens.size() < 2)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tinvalid [ exclusions ] entry in GROMACS "
+                    "topology\n");
+            }
+            int atom_i = std::stoi(tokens[0]) - 1;
+            for (std::size_t i = 1; i < tokens.size(); i++)
+            {
+                int atom_j = std::stoi(tokens[i]) - 1;
+                if (atom_i < 0 || atom_j < 0 || atom_i == atom_j ||
+                    atom_i >=
+                        static_cast<int>(current_molecule->atoms.size()) ||
+                    atom_j >= static_cast<int>(current_molecule->atoms.size()))
+                {
+                    controller->Throw_SPONGE_Error(
+                        spongeErrorBadFileFormat, error_by,
+                        "Reason:\n\tinvalid atom pair in GROMACS [ exclusions "
+                        "]\n");
+                }
+                current_molecule->exclusions.insert(
+                    {std::min(atom_i, atom_j), std::max(atom_i, atom_j)});
+            }
+        }
         else if (current_section == "cmap")
         {
             if (current_molecule == NULL || tokens.size() < 6)
@@ -1380,6 +1448,13 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                 }
             };
 
+            std::set<std::pair<int, int>> exclusion_pairs = molecule.exclusions;
+            for (const std::pair<int, int>& exclusion : exclusion_pairs)
+            {
+                require_local_atom(exclusion.first);
+                require_local_atom(exclusion.second);
+            }
+
             auto append_bond =
                 [&](int ai_local, int aj_local, float k, float r0)
             {
@@ -1501,10 +1576,15 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                 {
                     if (distance[j] > 0 && distance[j] <= molecule.nrexcl)
                     {
-                        system->exclusions.excluded_atoms[local_to_global[i]]
-                            .push_back(local_to_global[j]);
+                        exclusion_pairs.insert({i, j});
                     }
                 }
+            }
+            for (const std::pair<int, int>& exclusion : exclusion_pairs)
+            {
+                system->exclusions
+                    .excluded_atoms[local_to_global[exclusion.first]]
+                    .push_back(local_to_global[exclusion.second]);
             }
 
             for (const Gromacs_CMap& cmap_item : molecule.cmaps)

--- a/SPONGE/xponge/load/gromacs.hpp
+++ b/SPONGE/xponge/load/gromacs.hpp
@@ -1290,6 +1290,7 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
 
     std::vector<std::string> global_atom_types;
     std::vector<std::vector<int>> molecule_local_to_global;
+    std::size_t pairs_overridden_by_exclusions = 0;
 
     for (const auto& item : topology.system_molecules)
     {
@@ -1762,6 +1763,14 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
             {
                 int ai_local = pair.ai - 1;
                 int aj_local = pair.aj - 1;
+                // GROMACS semantics: an explicit [ exclusions ] entry removes
+                // the special 1-4 interaction from [ pairs ] entirely.
+                if (molecule.exclusions.count({std::min(ai_local, aj_local),
+                                               std::max(ai_local, aj_local)}))
+                {
+                    pairs_overridden_by_exclusions += 1;
+                    continue;
+                }
                 const Gromacs_Molecule_Atom& atom_i = molecule.atoms[ai_local];
                 const Gromacs_Molecule_Atom& atom_j = molecule.atoms[aj_local];
                 std::pair<float, float> c6_c12{0.0f, 0.0f};
@@ -1803,6 +1812,13 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                 nb14.cf_scale_factor.push_back(topology.defaults.fudge_qq);
             }
         }
+    }
+    if (pairs_overridden_by_exclusions > 0)
+    {
+        controller->printf(
+            "WARNING: %llu GROMACS [ pairs ] interaction(s) overridden by "
+            "explicit [ exclusions ]\n",
+            static_cast<unsigned long long>(pairs_overridden_by_exclusions));
     }
 }
 

--- a/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_section_integrity.py
+++ b/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_section_integrity.py
@@ -202,3 +202,74 @@ def test_explicit_exclusions_are_normalized_and_merged_with_nrexcl(tmp_path):
     assert _extract_mdout_term(with_mdout, "LJ_short") == pytest.approx(
         expected_at_0_7_nm, abs=0.011
     )
+
+
+def test_explicit_exclusions_override_pairs_14_interaction(tmp_path):
+    topology = """
+        [ defaults ]
+        1 2 yes 0.25 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.20 0.4184
+        B B 12.0 0.0 A 0.20 0.4184
+
+        [ nonbond_params ]
+        A B 1 0.40 4.184
+
+        [ moleculetype ]
+        PAIR 1
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 B 1 PAIR B 2 0.0 12.0
+
+        [ bonds ]
+        1 2 1 0.50 0.0
+
+        [ pairs ]
+        1 2 1
+
+        {exclusions}
+
+        [ system ]
+        explicit exclusions override pairs
+
+        [ molecules ]
+        PAIR 1
+    """
+    atoms = (("A", 0.0), ("B", 0.5))
+    without_result, without_mdout = _run_topology(
+        tmp_path / "without",
+        topology.format(exclusions=""),
+        atoms=atoms,
+    )
+    with_result, with_mdout = _run_topology(
+        tmp_path / "with",
+        topology.format(
+            exclusions="""
+            [ exclusions ]
+            1 2
+            """
+        ),
+        atoms=atoms,
+    )
+
+    assert without_result.returncode == 0, (
+        without_result.stdout + "\n" + without_result.stderr
+    )
+    sigma_over_r = 0.40 / 0.5
+    expected_pair_14 = 0.25 * 4.0 * (sigma_over_r**12 - sigma_over_r**6)
+    assert _extract_mdout_term(without_mdout, "nb14_LJ") == pytest.approx(
+        expected_pair_14, abs=0.011
+    )
+    assert with_result.returncode == 0, (
+        with_result.stdout + "\n" + with_result.stderr
+    )
+    # The nb14 columns disappear entirely once every pair is overridden.
+    with_lines = with_mdout.read_text().splitlines()
+    with_terms = dict(zip(with_lines[0].split(), with_lines[1].split()))
+    assert float(with_terms.get("nb14_LJ", 0.0)) == pytest.approx(
+        0.0, abs=0.011
+    )
+    output = with_result.stdout + "\n" + with_result.stderr
+    assert "overridden by explicit [ exclusions ]" in output

--- a/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_section_integrity.py
+++ b/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_section_integrity.py
@@ -1,0 +1,204 @@
+import json
+import os
+import subprocess
+import textwrap
+
+import pytest
+
+
+def _toml_string(value):
+    return json.dumps(os.fspath(value))
+
+
+def _gro_atom(resid, resname, atomname, atomnr, x):
+    return (
+        f"{resid:5d}{resname:<5}{atomname:>5}{atomnr:5d}"
+        f"{x:8.3f}{0.0:8.3f}{0.0:8.3f}"
+    )
+
+
+def _minimal_topology(injected="", system_text="section integrity test"):
+    return f"""
+        [ defaults ]
+        1 2 yes 1.0 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.30 0.4184
+
+        {injected}
+
+        [ moleculetype ]
+        ONE 0
+
+        [ atoms ]
+        1 A 1 ONE A 1 0.0 12.0
+
+        [ system ]
+        {system_text}
+
+        [ molecules ]
+        ONE 1
+    """
+
+
+def _run_topology(tmp_path, topology, atoms=(("A", 0.0),)):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    top_path = tmp_path / "topol.top"
+    gro_path = tmp_path / "conf.gro"
+    mdin_path = tmp_path / "mdin.spg.toml"
+    mdout_path = tmp_path / "mdout.txt"
+
+    top_path.write_text(textwrap.dedent(topology).strip() + "\n")
+    atom_lines = [
+        _gro_atom(1, "ONE", atom_name, index + 1, x)
+        for index, (atom_name, x) in enumerate(atoms)
+    ]
+    gro_path.write_text(
+        "\n".join(
+            [
+                "section integrity test",
+                str(len(atom_lines)),
+                *atom_lines,
+                "   5.00000   5.00000   5.00000",
+            ]
+        )
+        + "\n"
+    )
+    mdin_path.write_text(
+        textwrap.dedent(
+            f"""
+            md_name = "direct_gromacs_section_integrity"
+            mode = "nve"
+            step_limit = 0
+            dt = 0
+            cutoff = 8.0
+            gromacs_top = {_toml_string(top_path)}
+            gromacs_gro = {_toml_string(gro_path)}
+            mdout = {_toml_string(mdout_path)}
+            print_zeroth_frame = 1
+            write_mdout_interval = 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+    result = subprocess.run(
+        [os.environ.get("SPONGE_BIN", "SPONGE"), "-mdin", str(mdin_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    return result, mdout_path
+
+
+def _extract_mdout_term(mdout_path, term_name):
+    lines = mdout_path.read_text().splitlines()
+    headers = lines[0].split()
+    values = lines[1].split()
+    assert len(headers) == len(values)
+    return float(dict(zip(headers, values))[term_name])
+
+
+def test_active_unsupported_section_in_include_reports_source_line(tmp_path):
+    include_path = tmp_path / "unsupported.itp"
+    include_path.write_text("; metadata\n\n[ virtual_sites2 \\\n]\n1 1 1 0.5\n")
+
+    result, _ = _run_topology(
+        tmp_path,
+        _minimal_topology('#include "unsupported.itp"'),
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode != 0
+    assert "spongeErrorBadFileFormat" in output
+    assert "unsupported GROMACS topology section [ virtual_sites2 ]" in output
+    assert f"{include_path}:3" in output
+
+
+def test_unsupported_section_in_inactive_branch_is_not_parsed(tmp_path):
+    result, _ = _run_topology(
+        tmp_path,
+        _minimal_topology(
+            """
+            #ifdef NEVER_DEFINED
+            [ virtual_sites2 ]
+            #endif
+            """
+        ),
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0, output
+    assert "unsupported GROMACS topology section" not in output
+
+
+def test_system_metadata_section_is_explicitly_allowed(tmp_path):
+    result, _ = _run_topology(
+        tmp_path,
+        _minimal_topology(system_text="arbitrary human-readable system name"),
+    )
+
+    assert result.returncode == 0, result.stdout + "\n" + result.stderr
+
+
+def test_explicit_exclusions_are_normalized_and_merged_with_nrexcl(tmp_path):
+    topology = """
+        [ defaults ]
+        1 2 yes 1.0 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.30 4.184
+
+        [ moleculetype ]
+        TRIPLE 1
+
+        [ atoms ]
+        1 A 1 TRIPLE A1 1 0.0 12.0
+        2 A 1 TRIPLE A2 2 0.0 12.0
+        3 A 1 TRIPLE A3 3 0.0 12.0
+
+        [ bonds ]
+        1 2 1 0.35 0.0
+
+        {exclusions}
+
+        [ system ]
+        explicit exclusions
+
+        [ molecules ]
+        TRIPLE 1
+    """
+    atoms = (("A1", 0.0), ("A2", 0.35), ("A3", 0.7))
+    without_result, without_mdout = _run_topology(
+        tmp_path / "without",
+        topology.format(exclusions=""),
+        atoms=atoms,
+    )
+    with_result, with_mdout = _run_topology(
+        tmp_path / "with",
+        topology.format(
+            exclusions="""
+            [ exclusions ]
+            2 3 3
+            3 2
+            """
+        ),
+        atoms=atoms,
+    )
+
+    assert without_result.returncode == 0, (
+        without_result.stdout + "\n" + without_result.stderr
+    )
+    assert with_result.returncode == 0, (
+        with_result.stdout + "\n" + with_result.stderr
+    )
+    expected_at_0_35_nm = 4.0 * ((0.30 / 0.35) ** 12 - (0.30 / 0.35) ** 6)
+    expected_at_0_7_nm = 4.0 * ((0.30 / 0.7) ** 12 - (0.30 / 0.7) ** 6)
+    assert _extract_mdout_term(without_mdout, "LJ_short") == pytest.approx(
+        expected_at_0_35_nm + expected_at_0_7_nm, abs=0.011
+    )
+    assert _extract_mdout_term(with_mdout, "LJ_short") == pytest.approx(
+        expected_at_0_7_nm, abs=0.011
+    )


### PR DESCRIPTION
### 问题

gromacs 拓扑加载器此前存在两类静默错误：

1. `[ exclusions ]` 节被直接丢弃，显式排除不生效，体系静默算错
2. 未支持的 section 被静默跳过。最典型的例子是拓扑中 define 了 `POSRES` 引入的 `[ position_restraints ]`，旧版本照常运行但结果与用户意图不符

### 方案

- 解析 `[ exclusions ]`，去重归一化后与 nrexcl 派生的排除表合并
- 新增 `Gromacs_Source_Line` 行号/文件追踪（含 `#include` 链和续行），遇到未支持 section 时带 `文件:行号` 报错，变静默错算为显式失败
- `[ system ]` 等纯元数据节放行

### 行为变更

以前能跑（但结果错误）的拓扑现在会 hard error。报错优于静默出错。

### 显式 exclusions 覆盖 [ pairs ]

GROMACS 语义中显式 exclusion 会覆盖 `[ pairs ]` 的 1-4 相互作用。第二个提交在展开 `[ pairs ]` 时检查该原子对是否在分子的显式排除表中，若是则跳过该 1-4 项并打印 WARNING 计数。注意只对显式 `[ exclusions ]` 判断，不用合并 nrexcl 后的完整排除表，否则正常的 1-4 pairs 会被错误过滤。