### PR TITLE
perf: speed up initialization-stage setup

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'lab/**'
     types:
       - opened
       - synchronize

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -139,8 +139,11 @@ jobs:
 
       - name: Install CPU backends for PRIPS
         shell: bash
+        env:
+          # PyTorch 2.14 macOS wheels load a second libomp into the SPONGE process.
+          PRIPS_TORCH_REQUIREMENT: ${{ matrix.target == 'osx-arm64' && 'torch==2.13.0' || 'torch' }}
         run: |
-          pixi run -e ${{ matrix.env_name }} python -m pip install "jax[cpu]" torch
+          pixi run -e ${{ matrix.env_name }} python -m pip install "jax[cpu]" "$PRIPS_TORCH_REQUIREMENT"
 
       - name: Benchmark validation/prips (jax)
         run: pixi run -e ${{ matrix.env_name }} vali-misc -k prips

--- a/.github/workflows/bundled-io-ab-shadow.yml
+++ b/.github/workflows/bundled-io-ab-shadow.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'lab/**'
     paths:
       - "SPONGE/**"
       - "benchmarks/bundled_io/**"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'lab/**'
     types:
       - opened
       - synchronize

--- a/SPONGE/Lennard_Jones_force/Lennard_Jones_force.cpp
+++ b/SPONGE/Lennard_Jones_force/Lennard_Jones_force.cpp
@@ -143,46 +143,6 @@ void LENNARD_JONES_INFORMATION::LJ_Malloc()
     Malloc_Safely((void**)&h_LJ_energy_atom, sizeof(float) * atom_numbers);
 }
 
-static __global__ void Total_C6_Get(int atom_numbers, int* atom_lj_type,
-                                    float* d_lj_b, float* d_factor)
-{
-    int j;
-    double temp_sum = 0;
-    int x, y;
-    int itype, jtype, atom_pair_LJ_type;
-#ifdef USE_GPU
-    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < atom_numbers;
-         i += gridDim.x * blockDim.x)
-#else
-#pragma omp parallel for firstprivate( \
-        j, x, y, itype, jtype, atom_pair_LJ_type) reduction(+ : temp_sum)
-    for (int i = 0; i < atom_numbers; i++)
-#endif
-    {
-        itype = atom_lj_type[i];
-        double temp_small_sum = 0;
-#ifdef USE_GPU
-        for (j = blockIdx.y * blockDim.y + threadIdx.y; j < atom_numbers;
-             j += gridDim.y * blockDim.y)
-#else
-        for (j = 0; j < atom_numbers; j++)
-#endif
-        {
-            jtype = atom_lj_type[j];
-            y = (jtype - itype);
-            x = y >> 31;
-            y = (y ^ x) - x;
-            x = jtype + itype;
-            jtype = (x + y) >> 1;
-            x = (x - y) >> 1;
-            atom_pair_LJ_type = (jtype * (jtype + 1) >> 1) + x;
-            temp_small_sum += d_lj_b[atom_pair_LJ_type];
-        }
-        temp_sum += temp_small_sum;
-    }
-    atomicAdd(d_factor, temp_sum);
-}
-
 void LENNARD_JONES_INFORMATION::Initial(CONTROLLER* controller, float cutoff,
                                         const char* module_name)
 {
@@ -244,24 +204,30 @@ void LENNARD_JONES_INFORMATION::Initial(CONTROLLER* controller, float cutoff,
             CONTROLLER::device_max_thread, 0, NULL, atom_numbers,
             crd_with_LJ_parameters, d_atom_LJ_type);
         controller->printf("    Start initializing long range LJ correction\n");
-        long_range_factor = 0;
-
-        Device_Malloc_And_Copy_Safely((void**)&d_long_range_factor,
-                                      &long_range_factor, sizeof(float));
-        deviceMemset(d_long_range_factor, 0, sizeof(float));
-
-        dim3 gridSize = {(atom_numbers + CONTROLLER::device_max_thread - 1) /
-                             CONTROLLER::device_max_thread,
-                         1};
-        dim3 blockSize = {
-            CONTROLLER::device_warp,
-            CONTROLLER::device_max_thread / CONTROLLER::device_warp};
-        Launch_Device_Kernel(Total_C6_Get, gridSize, blockSize, 0, NULL,
-                             atom_numbers, d_atom_LJ_type, d_LJ_B,
-                             d_long_range_factor);
-
-        deviceMemcpy(&long_range_factor, d_long_range_factor, sizeof(float),
-                     deviceMemcpyDeviceToHost);
+        // 全对求和 Σ_i Σ_j B[type_i, type_j] 等于按类型直方图的
+        // Σ_a count_a · Σ_b count_b · B[pair(a,b)]，后者按固定顺序双精度
+        // 累加，结果确定；此前的全对 kernel 复杂度为 O(N²) 且依赖 float
+        // 原子加顺序，本身就有运行间波动。
+        std::vector<int64_t> type_count(atom_type_numbers, 0);
+        for (int i = 0; i < atom_numbers; i++)
+        {
+            type_count[h_atom_LJ_type[i]] += 1;
+        }
+        double c6_sum = 0.0;
+        for (int itype = 0; itype < atom_type_numbers; itype++)
+        {
+            if (type_count[itype] == 0) continue;
+            double inner_sum = 0.0;
+            for (int jtype = 0; jtype < atom_type_numbers; jtype++)
+            {
+                if (type_count[jtype] == 0) continue;
+                inner_sum +=
+                    static_cast<double>(type_count[jtype]) *
+                    static_cast<double>(h_LJ_B[Get_LJ_Type(itype, jtype)]);
+            }
+            c6_sum += static_cast<double>(type_count[itype]) * inner_sum;
+        }
+        long_range_factor = static_cast<float>(c6_sum);
         printf("        Total C6 factor is %e\n", long_range_factor);
 
         long_range_factor *=

--- a/SPONGE/Lennard_Jones_force/Lennard_Jones_force.h
+++ b/SPONGE/Lennard_Jones_force/Lennard_Jones_force.h
@@ -163,7 +163,6 @@ struct LENNARD_JONES_INFORMATION
 
     // 长程能量和维里修正
     float long_range_factor = 0;
-    float* d_long_range_factor = NULL;
     // 求力的时候对能量和维里的长程修正
     void Long_Range_Correction(int need_pressure, LTMatrix3* d_virial,
                                int need_potential, float* d_potential,

--- a/SPONGE/MD_core/mol.hpp
+++ b/SPONGE/MD_core/mol.hpp
@@ -724,11 +724,9 @@ static void Get_Molecule_Atoms(CONTROLLER* controller, int atom_numbers,
     free(edge_next);
 }
 
-static std::vector<int> Check_Periodic_Molecules(CPP_ATOM_GROUP mol_atoms,
-                                                 const CONECT connectivity,
-                                                 const VECTOR* crd,
-                                                 const LTMatrix3 cell,
-                                                 const LTMatrix3 rcell)
+static std::vector<int> Check_Periodic_Molecules(
+    const CPP_ATOM_GROUP& mol_atoms, const CONECT& connectivity,
+    const VECTOR* crd, const LTMatrix3 cell, const LTMatrix3 rcell)
 {
     std::vector<int> periodic_mols;
     int max_atom_idx = -1;
@@ -746,6 +744,7 @@ static std::vector<int> Check_Periodic_Molecules(CPP_ATOM_GROUP mol_atoms,
 
     std::vector<int> mark(max_atom_idx + 1, 0);
     std::vector<int> visited(max_atom_idx + 1, 0);
+    std::vector<VECTOR> mapped(max_atom_idx + 1);
     std::deque<int> queue;
 
     for (int i = 0; i < mol_atoms.size(); i++)
@@ -770,7 +769,6 @@ static std::vector<int> Check_Periodic_Molecules(CPP_ATOM_GROUP mol_atoms,
         frac0.z = frac0.z - floorf(frac0.z);
         VECTOR mapped_anchor = frac0 * cell;
 
-        std::vector<VECTOR> mapped(max_atom_idx + 1);
         mapped[anchor] = mapped_anchor;
         visited[anchor] = 1;
         queue.clear();

--- a/SPONGE/MD_core/mol.hpp
+++ b/SPONGE/MD_core/mol.hpp
@@ -654,14 +654,16 @@ static void Get_Atom_Group_From_Edges(const int atom_numbers, const int* edges,
 }
 
 static void Get_Molecule_Atoms(CONTROLLER* controller, int atom_numbers,
-                               CONECT connectivity, CPP_ATOM_GROUP& mol_atoms,
+                               const CONECT& connectivity,
+                               CPP_ATOM_GROUP& mol_atoms,
                                std::vector<int>& molecule_belongings)
 {
     // 分子拓扑是一个无向图，邻接表进行描述
     int edge_numbers = 0;
     for (int i = 0; i < atom_numbers; i++)
     {
-        edge_numbers += connectivity[i].size();
+        auto it = connectivity.find(i);
+        if (it != connectivity.end()) edge_numbers += it->second.size();
     }
     edge_numbers *= 2;
     int* first_edge = NULL;  // 每个原子的第一个边（链表的头）
@@ -676,12 +678,13 @@ static void Get_Molecule_Atoms(CONTROLLER* controller, int atom_numbers,
         first_edge[i] = -1;
     }
     int atom_i, atom_j, edge_count = 0;
-    for (int atom_i = 0; atom_i < atom_numbers; atom_i++)
+    for (atom_i = 0; atom_i < atom_numbers; atom_i++)
     {
-        std::set<int> conect_i = connectivity[atom_i];
-        for (auto iter = conect_i.begin(); iter != conect_i.end(); iter++)
+        auto it = connectivity.find(atom_i);
+        if (it == connectivity.end()) continue;
+        for (int atom_j_value : it->second)
         {
-            atom_j = *iter;
+            atom_j = atom_j_value;
             edge_next[edge_count] = first_edge[atom_i];
             first_edge[atom_i] = edge_count;
             edges[edge_count] = atom_j;
@@ -819,7 +822,7 @@ static std::vector<int> Check_Periodic_Molecules(
 }
 
 static void Move_Crd_Nearest_From_Connectivity(
-    CPP_ATOM_GROUP mol_atoms, const CONECT connectivity, VECTOR* crd,
+    const CPP_ATOM_GROUP& mol_atoms, const CONECT& connectivity, VECTOR* crd,
     const LTMatrix3 cell, const LTMatrix3 rcell,
     std::vector<int> periodic_molecules)
 {

--- a/SPONGE/MD_core/ug.hpp
+++ b/SPONGE/MD_core/ug.hpp
@@ -33,7 +33,7 @@ void MD_INFORMATION::update_group_information::Read_Update_Group(
     int atom_i, atom_j, edge_count = 0;
     for (atom_i = 0; atom_i < atom_numbers; atom_i++)
     {
-        std::set<int> conect_i = connectivity[atom_i];
+        const std::set<int>& conect_i = connectivity[atom_i];
         for (auto iter = conect_i.begin(); iter != conect_i.end(); iter++)
         {
             atom_j = *iter;
@@ -111,20 +111,18 @@ void MD_INFORMATION::update_group_information::Copy_UG_To_Device()
     // 创建临时数组用于存储设备上的 ATOM_GROUP 数据
     ATOM_GROUP* h_ug_tmp = (ATOM_GROUP*)malloc(sizeof(ATOM_GROUP) * ug_numbers);
 
-    // 逐个复制 ATOM_GROUP 数据
     int offset = 0;
     for (int i = 0; i < ug_numbers; i++)
     {
         h_ug_tmp[i].atom_numbers = ug[i].atom_numbers;
         h_ug_tmp[i].ghost_numbers = ug[i].ghost_numbers;
         h_ug_tmp[i].atom_serial = d_atom_serials + offset;
-
-        // 将 atom_serial 数据复制到设备
-        deviceMemcpy(d_atom_serials + offset, ug[i].atom_serial,
-                     sizeof(int) * ug[i].atom_numbers,
-                     deviceMemcpyHostToDevice);
         offset += ug[i].atom_numbers;
     }
+
+    // ug[i].atom_serial 指向同一块连续主机内存且按组序排列，一次拷贝即可
+    deviceMemcpy(d_atom_serials, ug[0].atom_serial,
+                 sizeof(int) * total_atom_serials, deviceMemcpyHostToDevice);
 
     // 将 ATOM_GROUP 数组复制到设备
     deviceMemcpy(d_ug, h_ug_tmp, sizeof(ATOM_GROUP) * ug_numbers,

--- a/SPONGE/neighbor_list/neighbor_list.cpp
+++ b/SPONGE/neighbor_list/neighbor_list.cpp
@@ -1,6 +1,77 @@
 ﻿#include "neighbor_list.h"
 
+#include <cstdint>
+
 #define MAX_GRID_NEIGHBORS 192
+
+// 按 grid_j 升序逐个检查 27 种周期镜像位移，命中即记录，输出为升序邻居表。
+static __host__ __device__ __forceinline__ int Find_Neighbor_Grids_Scan(
+    int grid_i, int Nx, int Ny, int Nz, int64_t dxy, int64_t dxz, int64_t dyz,
+    LTMatrix3 cell, int* neighbor_i)
+{
+    const int64_t NyNz = static_cast<int64_t>(Ny) * Nz;
+    int local = 0;
+    int dx, dy, dz;
+    const int64_t grid_i_x = grid_i / NyNz;
+    const int64_t grid_i_y = (grid_i % NyNz) / Nz;
+    const int64_t grid_i_z = grid_i % Nz;
+    int cx, cy;
+    int grid_j = 0;
+    for (int64_t grid_j_x = 0; grid_j_x < Nx; grid_j_x += 1)
+    {
+        const int64_t base_x = grid_i_x - grid_j_x;
+        for (int64_t grid_j_y = 0; grid_j_y < Ny; grid_j_y += 1)
+        {
+            const int64_t base_y = grid_i_y - grid_j_y;
+            for (int64_t grid_j_z = 0; grid_j_z < Nz;
+                 grid_j_z += 1, grid_j += 1)
+            {
+                const int64_t base_z = grid_i_z - grid_j_z;
+                for (int k = 0; k < 27; k += 1)
+                {
+                    dx = k / 9 - 1;
+                    dy = (k % 9) / 3 - 1;
+                    dz = k % 3 - 1;
+                    const int64_t temp_x = base_x +
+                                           static_cast<int64_t>(dx) * Nx +
+                                           dy * dxy + dz * dxz;
+                    const int64_t temp_y =
+                        base_y + static_cast<int64_t>(dy) * Ny + dz * dyz;
+                    const int64_t temp_z =
+                        base_z + static_cast<int64_t>(dz) * Nz;
+                    cx = static_cast<double>(dy) * cell.a21 +
+                                     static_cast<double>(dz) * cell.a31 ==
+                                 0.0
+                             ? -2
+                             : -3;
+                    cy = static_cast<double>(dz) * cell.a32 == 0.0 ? -2 : -3;
+                    if (temp_x <= 2 && temp_x >= cx && temp_y <= 2 &&
+                        temp_y >= cy && temp_z <= 2 && temp_z >= -2)
+                    {
+                        if (local >= MAX_GRID_NEIGHBORS)
+                        {
+                            local = -1;
+                        }
+                        else
+                        {
+                            neighbor_i[local++] = grid_j;
+                        }
+                        break;
+                    }
+                }
+                if (local < 0) break;
+            }
+            if (local < 0) break;
+        }
+        if (local < 0) break;
+    }
+    return local;
+}
+
+#ifdef GPU_ARCH_NAME
+// 枚举路径单线程候选上限；超出即回退到全扫描，语义不变
+#define GRID_ENUM_CAPACITY 2048
+#endif
 
 static __global__ void Find_Neighor_Grids_Device(
     int grid_numbers, int* neighbor_grid_numbers, int* neighbor_grids, int Nx,
@@ -8,42 +79,108 @@ static __global__ void Find_Neighor_Grids_Device(
 {
     SIMPLE_DEVICE_FOR(grid_i, grid_numbers)
     {
-        int NyNz = Ny * Nz;
+        const int64_t dxy = static_cast<int64_t>(cell.a21 / grid_length);
+        const int64_t dxz = static_cast<int64_t>(cell.a31 / grid_length);
+        const int64_t dyz = static_cast<int64_t>(cell.a32 / grid_length);
+        int* neighbor_i = neighbor_grids + (size_t)MAX_GRID_NEIGHBORS * grid_i;
         int local = 0;
-        int dx, dy, dz;
-        int* neighbor_i = neighbor_grids + MAX_GRID_NEIGHBORS * grid_i;
-        INT_VECTOR grid_i_xyz = {grid_i / NyNz, (grid_i % NyNz) / Nz,
-                                 grid_i % Nz};
-        INT_VECTOR grid_j_xyz, temp_delta;
-        int dxy = cell.a21 / grid_length;
-        int dxz = cell.a31 / grid_length;
-        int dyz = cell.a32 / grid_length;
-        int cx, cy;
-        for (int grid_j = 0; grid_j < grid_numbers; grid_j += 1)
+#ifdef GPU_ARCH_NAME
+        // 全扫描是 O(grid_numbers^2)。命中条件对每种周期镜像 (dx,dy,dz)
+        // 都是关于 grid_j 三个分量的区间约束，因此可以按镜像直接枚举候选
+        // 小盒，再排序去重得到与全扫描逐位一致的升序邻居表。
+        const int64_t grid_i_x = grid_i / (static_cast<int64_t>(Ny) * Nz);
+        const int64_t grid_i_y =
+            (grid_i % (static_cast<int64_t>(Ny) * Nz)) / Nz;
+        const int64_t grid_i_z = grid_i % Nz;
+        int candidates[GRID_ENUM_CAPACITY];
+        int candidate_numbers = 0;
+        bool enumeration_ok = true;
+        for (int k = 0; k < 27 && enumeration_ok; k += 1)
         {
-            grid_j_xyz = {grid_j / NyNz, (grid_j % NyNz) / Nz, grid_j % Nz};
-            for (int k = 0; k < 27; k += 1)
+            const int dx = k / 9 - 1;
+            const int dy = (k % 9) / 3 - 1;
+            const int dz = k % 3 - 1;
+            const int cx = static_cast<double>(dy) * cell.a21 +
+                                       static_cast<double>(dz) * cell.a31 ==
+                                   0.0
+                               ? -2
+                               : -3;
+            const int cy = static_cast<double>(dz) * cell.a32 == 0.0 ? -2 : -3;
+            const int64_t shift_x =
+                static_cast<int64_t>(dx) * Nx + dy * dxy + dz * dxz;
+            const int64_t shift_y = static_cast<int64_t>(dy) * Ny + dz * dyz;
+            const int64_t shift_z = static_cast<int64_t>(dz) * Nz;
+            const int64_t lo_x =
+                grid_i_x + shift_x - 2 > 0 ? grid_i_x + shift_x - 2 : 0;
+            const int64_t hi_x = grid_i_x + shift_x - cx < Nx - 1
+                                     ? grid_i_x + shift_x - cx
+                                     : Nx - 1;
+            const int64_t lo_y =
+                grid_i_y + shift_y - 2 > 0 ? grid_i_y + shift_y - 2 : 0;
+            const int64_t hi_y = grid_i_y + shift_y - cy < Ny - 1
+                                     ? grid_i_y + shift_y - cy
+                                     : Ny - 1;
+            const int64_t lo_z =
+                grid_i_z + shift_z - 2 > 0 ? grid_i_z + shift_z - 2 : 0;
+            const int64_t hi_z = grid_i_z + shift_z + 2 < Nz - 1
+                                     ? grid_i_z + shift_z + 2
+                                     : Nz - 1;
+            if (lo_x > hi_x || lo_y > hi_y || lo_z > hi_z) continue;
+            const int64_t box =
+                (hi_x - lo_x + 1) * (hi_y - lo_y + 1) * (hi_z - lo_z + 1);
+            if (candidate_numbers + box > GRID_ENUM_CAPACITY)
             {
-                dx = k / 9 - 1;
-                dy = (k % 9) / 3 - 1;
-                dz = k % 3 - 1;
-                temp_delta = {
-                    grid_i_xyz.int_x + dx * Nx + dy * dxy + dz * dxz -
-                        grid_j_xyz.int_x,
-                    grid_i_xyz.int_y + dy * Ny + dz * dyz - grid_j_xyz.int_y,
-                    grid_i_xyz.int_z + dz * Nz - grid_j_xyz.int_z};
-                cx = dy * cell.a21 + dz * cell.a31 == 0 ? -2 : -3;
-                cy = dz * cell.a32 == 0 ? -2 : -3;
-                if (temp_delta.int_x <= 2 && temp_delta.int_x >= cx &&
-                    temp_delta.int_y <= 2 && temp_delta.int_y >= cy &&
-                    temp_delta.int_z <= 2 && temp_delta.int_z >= -2)
+                enumeration_ok = false;
+                break;
+            }
+            for (int64_t jx = lo_x; jx <= hi_x; jx += 1)
+            {
+                for (int64_t jy = lo_y; jy <= hi_y; jy += 1)
                 {
-                    neighbor_i[local] = grid_j;
-                    local += 1;
-                    break;
+                    for (int64_t jz = lo_z; jz <= hi_z; jz += 1)
+                    {
+                        candidates[candidate_numbers] =
+                            static_cast<int>((jx * Ny + jy) * Nz + jz);
+                        candidate_numbers += 1;
+                    }
                 }
             }
         }
+        if (enumeration_ok)
+        {
+            for (int gap = candidate_numbers / 2; gap > 0; gap /= 2)
+            {
+                for (int i = gap; i < candidate_numbers; i += 1)
+                {
+                    const int value = candidates[i];
+                    int j = i;
+                    for (; j >= gap && candidates[j - gap] > value; j -= gap)
+                    {
+                        candidates[j] = candidates[j - gap];
+                    }
+                    candidates[j] = value;
+                }
+            }
+            for (int i = 0; i < candidate_numbers; i += 1)
+            {
+                if (i > 0 && candidates[i] == candidates[i - 1]) continue;
+                if (local >= MAX_GRID_NEIGHBORS)
+                {
+                    local = -1;
+                    break;
+                }
+                neighbor_i[local++] = candidates[i];
+            }
+        }
+        else
+        {
+            local = Find_Neighbor_Grids_Scan(grid_i, Nx, Ny, Nz, dxy, dxz, dyz,
+                                             cell, neighbor_i);
+        }
+#else
+        local = Find_Neighbor_Grids_Scan(grid_i, Nx, Ny, Nz, dxy, dxz, dyz,
+                                         cell, neighbor_i);
+#endif
         neighbor_grid_numbers[grid_i] = local;
     }
 }


### PR DESCRIPTION
### 概述

针对大体系、短轨迹发射的启动耗时优化，全部位于初始化/预加载路径：

| 阶段 | 优化前 | 优化后 |
|---|---|---|
| 分子周期性检查（映射缓冲复用） | 41.1 s | 0.12 s |
| update-group / 分子 setup 图拷贝去除 | 9.2 s | 7.8 s（累计） |
| 邻居网格拓扑构建（候选枚举） | 7.8 s | 6.2 s（累计；kernel 1.55 s → ~1 ms） |
| LJ C6 因子（类型直方图） | 6.2 s | 5.3 s（累计；0.86 s → ~0.01 s） |
| **初始化总耗时** | **50.9 s** | **5.3 s** |

测量环境：Spike 55.6 万原子体系，RTX 5090，warm cache。

### 各提交要点

1. `perf(md): reuse mapping buffer across molecules in periodicity check`：原实现在逐分子循环内分配 max_atom_idx+1 的向量，大体系下每次启动零初始化约 1 TB。提出循环复用。
2. `perf(md): remove graph copies in update-group and molecule setup`：update-group 原子编号本就在连续宿主内存中，合并为一次 memcpy 上传
3. `perf(neighbor): enumerate image candidates in grid topology build`：命中条件对每种周期镜像是 grid_j 分量的区间约束，改为直接枚举候选小盒后排序去重，与全扫描逐位一致。候选数超栈上缓冲时回退原全扫描，CPU 构建保持全扫描。
  * 邻居数超 MAX_GRID_NEIGHBORS 时返回 −1 哨兵值（之前的实现中这种情况会越界写，属潜在 bug，新代码至少不破坏内存，如需可改为显式报错）
5. `perf(lj): compute long-range C6 factor from a type histogram`：双重求和按类型直方图在宿主端以固定顺序 double 累加完成，顺带消除原 atomicAdd float 累加导致的逐运行抖动（观测 ~1.6e-5 相对）。结果的确定性变化小于原分布，能量验证 LJ_long 在 GPU 噪声水平。