### PR TITLE
merge(pku): integrate constraint fixes, GROMACS handling and initialization optimizations

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'lab/**'
     types:
       - opened
       - synchronize

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -139,8 +139,11 @@ jobs:
 
       - name: Install CPU backends for PRIPS
         shell: bash
+        env:
+          # PyTorch 2.14 macOS wheels load a second libomp into the SPONGE process.
+          PRIPS_TORCH_REQUIREMENT: ${{ matrix.target == 'osx-arm64' && 'torch==2.13.0' || 'torch' }}
         run: |
-          pixi run -e ${{ matrix.env_name }} python -m pip install "jax[cpu]" torch
+          pixi run -e ${{ matrix.env_name }} python -m pip install "jax[cpu]" "$PRIPS_TORCH_REQUIREMENT"
 
       - name: Benchmark validation/prips (jax)
         run: pixi run -e ${{ matrix.env_name }} vali-misc -k prips

--- a/.github/workflows/bundled-io-ab-shadow.yml
+++ b/.github/workflows/bundled-io-ab-shadow.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'lab/**'
     paths:
       - "SPONGE/**"
       - "benchmarks/bundled_io/**"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'lab/**'
     types:
       - opened
       - synchronize

--- a/SPONGE/Lennard_Jones_force/Lennard_Jones_force.cpp
+++ b/SPONGE/Lennard_Jones_force/Lennard_Jones_force.cpp
@@ -143,46 +143,6 @@ void LENNARD_JONES_INFORMATION::LJ_Malloc()
     Malloc_Safely((void**)&h_LJ_energy_atom, sizeof(float) * atom_numbers);
 }
 
-static __global__ void Total_C6_Get(int atom_numbers, int* atom_lj_type,
-                                    float* d_lj_b, float* d_factor)
-{
-    int j;
-    double temp_sum = 0;
-    int x, y;
-    int itype, jtype, atom_pair_LJ_type;
-#ifdef USE_GPU
-    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < atom_numbers;
-         i += gridDim.x * blockDim.x)
-#else
-#pragma omp parallel for firstprivate( \
-        j, x, y, itype, jtype, atom_pair_LJ_type) reduction(+ : temp_sum)
-    for (int i = 0; i < atom_numbers; i++)
-#endif
-    {
-        itype = atom_lj_type[i];
-        double temp_small_sum = 0;
-#ifdef USE_GPU
-        for (j = blockIdx.y * blockDim.y + threadIdx.y; j < atom_numbers;
-             j += gridDim.y * blockDim.y)
-#else
-        for (j = 0; j < atom_numbers; j++)
-#endif
-        {
-            jtype = atom_lj_type[j];
-            y = (jtype - itype);
-            x = y >> 31;
-            y = (y ^ x) - x;
-            x = jtype + itype;
-            jtype = (x + y) >> 1;
-            x = (x - y) >> 1;
-            atom_pair_LJ_type = (jtype * (jtype + 1) >> 1) + x;
-            temp_small_sum += d_lj_b[atom_pair_LJ_type];
-        }
-        temp_sum += temp_small_sum;
-    }
-    atomicAdd(d_factor, temp_sum);
-}
-
 void LENNARD_JONES_INFORMATION::Initial(CONTROLLER* controller, float cutoff,
                                         const char* module_name)
 {
@@ -244,24 +204,30 @@ void LENNARD_JONES_INFORMATION::Initial(CONTROLLER* controller, float cutoff,
             CONTROLLER::device_max_thread, 0, NULL, atom_numbers,
             crd_with_LJ_parameters, d_atom_LJ_type);
         controller->printf("    Start initializing long range LJ correction\n");
-        long_range_factor = 0;
-
-        Device_Malloc_And_Copy_Safely((void**)&d_long_range_factor,
-                                      &long_range_factor, sizeof(float));
-        deviceMemset(d_long_range_factor, 0, sizeof(float));
-
-        dim3 gridSize = {(atom_numbers + CONTROLLER::device_max_thread - 1) /
-                             CONTROLLER::device_max_thread,
-                         1};
-        dim3 blockSize = {
-            CONTROLLER::device_warp,
-            CONTROLLER::device_max_thread / CONTROLLER::device_warp};
-        Launch_Device_Kernel(Total_C6_Get, gridSize, blockSize, 0, NULL,
-                             atom_numbers, d_atom_LJ_type, d_LJ_B,
-                             d_long_range_factor);
-
-        deviceMemcpy(&long_range_factor, d_long_range_factor, sizeof(float),
-                     deviceMemcpyDeviceToHost);
+        // 全对求和 Σ_i Σ_j B[type_i, type_j] 等于按类型直方图的
+        // Σ_a count_a · Σ_b count_b · B[pair(a,b)]，后者按固定顺序双精度
+        // 累加，结果确定；此前的全对 kernel 复杂度为 O(N²) 且依赖 float
+        // 原子加顺序，本身就有运行间波动。
+        std::vector<int64_t> type_count(atom_type_numbers, 0);
+        for (int i = 0; i < atom_numbers; i++)
+        {
+            type_count[h_atom_LJ_type[i]] += 1;
+        }
+        double c6_sum = 0.0;
+        for (int itype = 0; itype < atom_type_numbers; itype++)
+        {
+            if (type_count[itype] == 0) continue;
+            double inner_sum = 0.0;
+            for (int jtype = 0; jtype < atom_type_numbers; jtype++)
+            {
+                if (type_count[jtype] == 0) continue;
+                inner_sum +=
+                    static_cast<double>(type_count[jtype]) *
+                    static_cast<double>(h_LJ_B[Get_LJ_Type(itype, jtype)]);
+            }
+            c6_sum += static_cast<double>(type_count[itype]) * inner_sum;
+        }
+        long_range_factor = static_cast<float>(c6_sum);
         printf("        Total C6 factor is %e\n", long_range_factor);
 
         long_range_factor *=

--- a/SPONGE/Lennard_Jones_force/Lennard_Jones_force.h
+++ b/SPONGE/Lennard_Jones_force/Lennard_Jones_force.h
@@ -163,7 +163,6 @@ struct LENNARD_JONES_INFORMATION
 
     // 长程能量和维里修正
     float long_range_factor = 0;
-    float* d_long_range_factor = NULL;
     // 求力的时候对能量和维里的长程修正
     void Long_Range_Correction(int need_pressure, LTMatrix3* d_virial,
                                int need_potential, float* d_potential,

--- a/SPONGE/MD_core/mol.hpp
+++ b/SPONGE/MD_core/mol.hpp
@@ -724,11 +724,9 @@ static void Get_Molecule_Atoms(CONTROLLER* controller, int atom_numbers,
     free(edge_next);
 }
 
-static std::vector<int> Check_Periodic_Molecules(CPP_ATOM_GROUP mol_atoms,
-                                                 const CONECT connectivity,
-                                                 const VECTOR* crd,
-                                                 const LTMatrix3 cell,
-                                                 const LTMatrix3 rcell)
+static std::vector<int> Check_Periodic_Molecules(
+    const CPP_ATOM_GROUP& mol_atoms, const CONECT& connectivity,
+    const VECTOR* crd, const LTMatrix3 cell, const LTMatrix3 rcell)
 {
     std::vector<int> periodic_mols;
     int max_atom_idx = -1;
@@ -746,6 +744,7 @@ static std::vector<int> Check_Periodic_Molecules(CPP_ATOM_GROUP mol_atoms,
 
     std::vector<int> mark(max_atom_idx + 1, 0);
     std::vector<int> visited(max_atom_idx + 1, 0);
+    std::vector<VECTOR> mapped(max_atom_idx + 1);
     std::deque<int> queue;
 
     for (int i = 0; i < mol_atoms.size(); i++)
@@ -770,7 +769,6 @@ static std::vector<int> Check_Periodic_Molecules(CPP_ATOM_GROUP mol_atoms,
         frac0.z = frac0.z - floorf(frac0.z);
         VECTOR mapped_anchor = frac0 * cell;
 
-        std::vector<VECTOR> mapped(max_atom_idx + 1);
         mapped[anchor] = mapped_anchor;
         visited[anchor] = 1;
         queue.clear();

--- a/SPONGE/MD_core/mol.hpp
+++ b/SPONGE/MD_core/mol.hpp
@@ -654,14 +654,16 @@ static void Get_Atom_Group_From_Edges(const int atom_numbers, const int* edges,
 }
 
 static void Get_Molecule_Atoms(CONTROLLER* controller, int atom_numbers,
-                               CONECT connectivity, CPP_ATOM_GROUP& mol_atoms,
+                               const CONECT& connectivity,
+                               CPP_ATOM_GROUP& mol_atoms,
                                std::vector<int>& molecule_belongings)
 {
     // 分子拓扑是一个无向图，邻接表进行描述
     int edge_numbers = 0;
     for (int i = 0; i < atom_numbers; i++)
     {
-        edge_numbers += connectivity[i].size();
+        auto it = connectivity.find(i);
+        if (it != connectivity.end()) edge_numbers += it->second.size();
     }
     edge_numbers *= 2;
     int* first_edge = NULL;  // 每个原子的第一个边（链表的头）
@@ -676,12 +678,13 @@ static void Get_Molecule_Atoms(CONTROLLER* controller, int atom_numbers,
         first_edge[i] = -1;
     }
     int atom_i, atom_j, edge_count = 0;
-    for (int atom_i = 0; atom_i < atom_numbers; atom_i++)
+    for (atom_i = 0; atom_i < atom_numbers; atom_i++)
     {
-        std::set<int> conect_i = connectivity[atom_i];
-        for (auto iter = conect_i.begin(); iter != conect_i.end(); iter++)
+        auto it = connectivity.find(atom_i);
+        if (it == connectivity.end()) continue;
+        for (int atom_j_value : it->second)
         {
-            atom_j = *iter;
+            atom_j = atom_j_value;
             edge_next[edge_count] = first_edge[atom_i];
             first_edge[atom_i] = edge_count;
             edges[edge_count] = atom_j;
@@ -819,7 +822,7 @@ static std::vector<int> Check_Periodic_Molecules(
 }
 
 static void Move_Crd_Nearest_From_Connectivity(
-    CPP_ATOM_GROUP mol_atoms, const CONECT connectivity, VECTOR* crd,
+    const CPP_ATOM_GROUP& mol_atoms, const CONECT& connectivity, VECTOR* crd,
     const LTMatrix3 cell, const LTMatrix3 rcell,
     std::vector<int> periodic_molecules)
 {

--- a/SPONGE/MD_core/ug.hpp
+++ b/SPONGE/MD_core/ug.hpp
@@ -33,7 +33,7 @@ void MD_INFORMATION::update_group_information::Read_Update_Group(
     int atom_i, atom_j, edge_count = 0;
     for (atom_i = 0; atom_i < atom_numbers; atom_i++)
     {
-        std::set<int> conect_i = connectivity[atom_i];
+        const std::set<int>& conect_i = connectivity[atom_i];
         for (auto iter = conect_i.begin(); iter != conect_i.end(); iter++)
         {
             atom_j = *iter;
@@ -111,20 +111,18 @@ void MD_INFORMATION::update_group_information::Copy_UG_To_Device()
     // 创建临时数组用于存储设备上的 ATOM_GROUP 数据
     ATOM_GROUP* h_ug_tmp = (ATOM_GROUP*)malloc(sizeof(ATOM_GROUP) * ug_numbers);
 
-    // 逐个复制 ATOM_GROUP 数据
     int offset = 0;
     for (int i = 0; i < ug_numbers; i++)
     {
         h_ug_tmp[i].atom_numbers = ug[i].atom_numbers;
         h_ug_tmp[i].ghost_numbers = ug[i].ghost_numbers;
         h_ug_tmp[i].atom_serial = d_atom_serials + offset;
-
-        // 将 atom_serial 数据复制到设备
-        deviceMemcpy(d_atom_serials + offset, ug[i].atom_serial,
-                     sizeof(int) * ug[i].atom_numbers,
-                     deviceMemcpyHostToDevice);
         offset += ug[i].atom_numbers;
     }
+
+    // ug[i].atom_serial 指向同一块连续主机内存且按组序排列，一次拷贝即可
+    deviceMemcpy(d_atom_serials, ug[0].atom_serial,
+                 sizeof(int) * total_atom_serials, deviceMemcpyHostToDevice);
 
     // 将 ATOM_GROUP 数组复制到设备
     deviceMemcpy(d_ug, h_ug_tmp, sizeof(ATOM_GROUP) * ug_numbers,

--- a/SPONGE/constrain/constrain.cpp
+++ b/SPONGE/constrain/constrain.cpp
@@ -57,6 +57,19 @@ void CONSTRAIN::Initial_Constrain(CONTROLLER* controller,
         fp = NULL;
     }
 
+    std::vector<int> constraint_degree(atom_numbers, 0);
+    maximum_constraint_degree = 0;
+    for (int i = 0; i < constrain_pair_numbers; ++i)
+    {
+        const CONSTRAIN_PAIR& pair = h_constrain_pair[i];
+        ++constraint_degree[pair.atom_i_serial];
+        ++constraint_degree[pair.atom_j_serial];
+        maximum_constraint_degree =
+            std::max(maximum_constraint_degree,
+                     std::max(constraint_degree[pair.atom_i_serial],
+                              constraint_degree[pair.atom_j_serial]));
+    }
+
     Device_Malloc_And_Copy_Safely(
         (void**)&d_constrain_pair, h_constrain_pair,
         sizeof(CONSTRAIN_PAIR) * constrain_pair_numbers);

--- a/SPONGE/constrain/constrain.h
+++ b/SPONGE/constrain/constrain.h
@@ -34,6 +34,7 @@ struct CONSTRAIN
 
     // 在实际计算中使用，体系总的constrain pair
     int constrain_pair_numbers = 0;
+    int maximum_constraint_degree = 0;
     CONSTRAIN_PAIR* h_constrain_pair = NULL;
     CONSTRAIN_PAIR* d_constrain_pair = NULL;
 

--- a/SPONGE/constrain/settle.cpp
+++ b/SPONGE/constrain/settle.cpp
@@ -1,5 +1,7 @@
 ﻿#include "settle.h"
 
+#include "velocity_projection.h"
+
 static __global__ void remember_triangle_BA_CA(
     const int num_triangle_local, const CONSTRAIN_TRIANGLE* triangles,
     const VECTOR* crd, const LTMatrix3 cell, const LTMatrix3 rcell,
@@ -720,7 +722,9 @@ compute_velocity_constraint_correction_settle(
         return false;
     }
 
-    VECTOR v_diff = vel[atom_i] - vel[atom_j];
+    const VECTOR velocity_i = vel[atom_i];
+    const VECTOR velocity_j = vel[atom_j];
+    VECTOR v_diff = velocity_i - velocity_j;
     float denom = (mass_i_inverse + mass_j_inverse) * dr2;
     if (denom < 1e-20f)
     {
@@ -731,8 +735,9 @@ compute_velocity_constraint_correction_settle(
     const float projection = dr * v_diff;
     if (constraint_violated != NULL)
     {
-        const float scale = sqrtf(dr2 * fmaxf(v_diff * v_diff, 1.0e-12f));
-        *constraint_violated = fabsf(projection) > relative_tolerance * scale;
+        const float tolerance = Velocity_Constraint_Residual_Tolerance(
+            dr2, velocity_i, velocity_j, v_diff, relative_tolerance);
+        *constraint_violated = fabsf(projection) > tolerance;
     }
     float lambda = projection / denom;
     correction_i[0] = (-mass_i_inverse * lambda) * dr;

--- a/SPONGE/constrain/settle.cpp
+++ b/SPONGE/constrain/settle.cpp
@@ -255,23 +255,170 @@ static __global__ void settle_triangle(
     }
 }
 
+static __device__ __forceinline__ unsigned int Settle_Float_Bits(float value)
+{
+#ifdef GPU_ARCH_NAME
+    return __float_as_uint(value);
+#elif defined(__GNUC__) || defined(__clang__)
+    unsigned int bits = 0;
+    static_assert(sizeof(bits) == sizeof(value),
+                  "SPONGE requires 32-bit IEEE-754 floats");
+    memcpy(&bits, &value, sizeof(value));
+    __asm__ __volatile__("" : "+r"(bits));
+    return bits;
+#else
+    unsigned int bits = 0;
+    memcpy(&bits, &value, sizeof(value));
+    return bits;
+#endif
+}
+
+static __device__ __forceinline__ unsigned long long Settle_Double_Bits(
+    double value)
+{
+#ifdef GPU_ARCH_NAME
+    return static_cast<unsigned long long>(__double_as_longlong(value));
+#else
+    unsigned long long bits = 0;
+    static_assert(sizeof(bits) == sizeof(value),
+                  "SPONGE requires 64-bit IEEE-754 doubles");
+    memcpy(&bits, &value, sizeof(value));
+#if defined(__GNUC__) || defined(__clang__)
+    __asm__ __volatile__("" : "+r"(bits));
+#endif
+    return bits;
+#endif
+}
+
+static __device__ __forceinline__ bool Settle_Double_Is_Finite(double value)
+{
+    const unsigned long long bits = Settle_Double_Bits(value);
+    return (bits & 0x7ff0000000000000ULL) != 0x7ff0000000000000ULL;
+}
+
+static __device__ __forceinline__ bool Settle_Double_Is_Finite_Nonnegative(
+    double value)
+{
+    const unsigned long long bits = Settle_Double_Bits(value);
+    const unsigned long long magnitude = bits & 0x7fffffffffffffffULL;
+    return (magnitude & 0x7ff0000000000000ULL) != 0x7ff0000000000000ULL &&
+           ((bits & 0x8000000000000000ULL) == 0ULL || magnitude == 0ULL);
+}
+
+static __device__ __forceinline__ double Settle_Pair_Precise_Radicand(
+    const VECTOR& r1, const VECTOR& r2, const float target,
+    double* perpendicular_squared)
+{
+    const double r1x = static_cast<double>(r1.x);
+    const double r1y = static_cast<double>(r1.y);
+    const double r1z = static_cast<double>(r1.z);
+    const double r2x = static_cast<double>(r2.x);
+    const double r2y = static_cast<double>(r2.y);
+    const double r2z = static_cast<double>(r2.z);
+    const double cross_x = r1y * r2z - r1z * r2y;
+    const double cross_y = r1z * r2x - r1x * r2z;
+    const double cross_z = r1x * r2y - r1y * r2x;
+    const double cross_squared =
+        cross_x * cross_x + cross_y * cross_y + cross_z * cross_z;
+    const double r2_squared = r2x * r2x + r2y * r2y + r2z * r2z;
+    const double target_double = static_cast<double>(target);
+    if (perpendicular_squared != NULL)
+    {
+        perpendicular_squared[0] = cross_squared / r2_squared;
+    }
+    return r2_squared * target_double * target_double - cross_squared;
+}
+
+// Keep the ordinary float path away from the tangent boundary.  Recompute an
+// uncertain discriminant so cancellation is not mistaken for either a valid
+// or a physically impossible constraint update.
+static __device__ __noinline__ bool Settle_Try_Precise_Pair_Solution(
+    const VECTOR& r1, const VECTOR& r2, const float target, float* k)
+{
+    const double radicand = Settle_Pair_Precise_Radicand(r1, r2, target, NULL);
+    const double r1r2 = static_cast<double>(r1.x) * r2.x +
+                        static_cast<double>(r1.y) * r2.y +
+                        static_cast<double>(r1.z) * r2.z;
+    const double r2r2 = static_cast<double>(r2.x) * r2.x +
+                        static_cast<double>(r2.y) * r2.y +
+                        static_cast<double>(r2.z) * r2.z;
+    if (!Settle_Double_Is_Finite_Nonnegative(radicand) ||
+        !Settle_Double_Is_Finite_Nonnegative(r2r2) || !(r2r2 > 0.0))
+    {
+        return false;
+    }
+    const double precise_k = (sqrt(radicand) - r1r2) / r2r2;
+    const double maximum_float = static_cast<double>(FLT_MAX);
+    if (!Settle_Double_Is_Finite(precise_k) || precise_k > maximum_float ||
+        precise_k < -maximum_float)
+    {
+        return false;
+    }
+    const float narrowed_k = static_cast<float>(precise_k);
+    if ((Settle_Float_Bits(narrowed_k) & 0x7f800000U) == 0x7f800000U)
+    {
+        return false;
+    }
+    k[0] = narrowed_k;
+    return true;
+}
+
+static __device__ __forceinline__ void Settle_Fail_Invalid_Pair(
+    const int pair_i, const CONSTRAIN_PAIR& pair, const int* atom_local,
+    const VECTOR& r1, const VECTOR& r2, const float radicand, const float dt,
+    int* invalid_pair)
+{
+#ifdef GPU_ARCH_NAME
+    double perpendicular_squared = 0.0;
+    const double precise_radicand = Settle_Pair_Precise_Radicand(
+        r1, r2, pair.constant_r, &perpendicular_squared);
+    const double perpendicular =
+        Settle_Double_Is_Finite_Nonnegative(perpendicular_squared)
+            ? sqrt(perpendicular_squared)
+            : -1.0;
+    printf(
+        "Fatal SPONGE SETTLE error: global atoms %d %d cannot produce a "
+        "finite real position-constraint update (target %.9g, "
+        "perpendicular %.17g, "
+        "radicand float/precise %.9g/%.17g, dt %.9g). "
+        "Reduce the timestep or minimize/equilibrate the input state.\n",
+        atom_local[pair.atom_i_serial], atom_local[pair.atom_j_serial],
+        static_cast<double>(pair.constant_r), perpendicular,
+        static_cast<double>(radicand), precise_radicand,
+        static_cast<double>(dt));
+#if defined(USE_CUDA)
+    asm volatile("trap;");
+#elif defined(USE_HIP)
+    __builtin_trap();
+#endif
+#else
+    (void)pair;
+    (void)atom_local;
+    (void)r1;
+    (void)r2;
+    (void)radicand;
+    (void)dt;
+    atomicExch(invalid_pair, pair_i);
+#endif
+}
+
 static __global__ void settle_pair(int num_task_local, CONSTRAIN_PAIR* pairs,
-                                   const float* d_mass, VECTOR* crd,
-                                   LTMatrix3 cell, LTMatrix3 rcell,
+                                   const int* atom_local, const float* d_mass,
+                                   VECTOR* crd, LTMatrix3 cell, LTMatrix3 rcell,
                                    VECTOR* last_pair_AB, float dt,
                                    float exp_gamma,
                                    float half_exp_gamma_plus_half, VECTOR* vel,
-                                   LTMatrix3* virial_tensor)
+                                   LTMatrix3* virial_tensor, int* invalid_pair)
 {
     CONSTRAIN_PAIR pair;
     VECTOR r1, r2, kr2;
-    float mA, mB, r0r0, r1r1, r1r2, r2r2, k;
+    float mA, mB, r0r0, r1r1, r1r2, r2r2, radicand, k;
 #ifdef USE_GPU
     int pair_i = blockIdx.x * blockDim.x + threadIdx.x;
     if (pair_i < num_task_local)
 #else
 #pragma omp parallel for private(pair, r1, r2, kr2, mA, mB, r0r0, r1r1, r1r2, \
-                                     r2r2, k)
+                                     r2r2, radicand, k)
     for (int pair_i = 0; pair_i < num_task_local; pair_i++)
 #endif
     {
@@ -288,7 +435,43 @@ static __global__ void settle_pair(int num_task_local, CONSTRAIN_PAIR* pairs,
         r1r2 = r1 * r2;
         r2r2 = r2 * r2;
 
-        k = (sqrt(r1r2 * r1r2 - r1r1 * r2r2 + r2r2 * r0r0) - r1r2) / r2r2;
+        const float projection_squared = r1r2 * r1r2;
+        const float length_product = r1r1 * r2r2;
+        const float target_product = r2r2 * r0r0;
+        radicand = projection_squared - length_product + target_product;
+        const float radicand_error_bound =
+            8.0f * FLT_EPSILON *
+            (projection_squared + length_product + target_product);
+        const unsigned int radicand_bits = Settle_Float_Bits(radicand);
+        const unsigned int radicand_magnitude = radicand_bits & 0x7fffffffU;
+        const unsigned int r2r2_bits = Settle_Float_Bits(r2r2);
+        const unsigned int r2r2_magnitude = r2r2_bits & 0x7fffffffU;
+        const bool finite_radicand =
+            (radicand_magnitude & 0x7f800000U) != 0x7f800000U;
+        const bool valid_r2r2 = (r2r2_bits & 0x80000000U) == 0U &&
+                                r2r2_magnitude != 0U &&
+                                (r2r2_magnitude & 0x7f800000U) != 0x7f800000U;
+        bool solved = false;
+        if (finite_radicand && valid_r2r2 && radicand > radicand_error_bound)
+        {
+            k = (sqrt(radicand) - r1r2) / r2r2;
+            solved = (Settle_Float_Bits(k) & 0x7f800000U) != 0x7f800000U;
+        }
+        else if (finite_radicand && valid_r2r2)
+        {
+            solved =
+                Settle_Try_Precise_Pair_Solution(r1, r2, pair.constant_r, &k);
+        }
+        if (!solved)
+        {
+            Settle_Fail_Invalid_Pair(pair_i, pair, atom_local, r1, r2, radicand,
+                                     dt, invalid_pair);
+#ifdef USE_GPU
+            return;
+#else
+            continue;
+#endif
+        }
         kr2 = k * r2;
 
         r1 = -mB * pair.constrain_k * kr2;
@@ -656,19 +839,61 @@ void SETTLE::Get_Local(const int* atom_local_id, const char* atom_local_label,
                  deviceMemcpyDeviceToHost);
 }
 
-void SETTLE::Do_SETTLE(const float* d_mass, VECTOR* crd, const LTMatrix3 cell,
+void SETTLE::Do_SETTLE(CONTROLLER* controller, const int* atom_local,
+                       const float* d_mass, VECTOR* crd, const LTMatrix3 cell,
                        const LTMatrix3 rcell, VECTOR* vel,
                        const int need_pressure, LTMatrix3* d_stress)
 {
     if (!is_initialized) return;
+#ifndef GPU_ARCH_NAME
+    int invalid_pair = -1;
+    int* invalid_pair_buffer = &invalid_pair;
+#else
+    int* invalid_pair_buffer = NULL;
+#endif
     Launch_Device_Kernel(settle_pair,
                          (num_pair_local + CONTROLLER::device_max_thread - 1) /
                              CONTROLLER::device_max_thread,
                          CONTROLLER::device_max_thread, 0, NULL, num_pair_local,
-                         d_pairs_local, d_mass, crd, cell, rcell, last_pair_AB,
-                         constrain->dt, constrain->v_factor,
+                         d_pairs_local, atom_local, d_mass, crd, cell, rcell,
+                         last_pair_AB, constrain->dt, constrain->v_factor,
                          constrain->x_factor, vel,
-                         virial_tensor + triangle_numbers);
+                         virial_tensor + triangle_numbers, invalid_pair_buffer);
+
+#ifndef GPU_ARCH_NAME
+    if (invalid_pair >= 0)
+    {
+        const CONSTRAIN_PAIR pair = d_pairs_local[invalid_pair];
+        const VECTOR r2 = last_pair_AB[invalid_pair];
+        const VECTOR r1 = Get_Periodic_Displacement(
+            crd[pair.atom_j_serial], crd[pair.atom_i_serial], cell, rcell);
+        const float r1r1 = r1 * r1;
+        const float r1r2 = r1 * r2;
+        const float r2r2 = r2 * r2;
+        const float target_squared = pair.constant_r * pair.constant_r;
+        const float radicand =
+            r1r2 * r1r2 - r1r1 * r2r2 + r2r2 * target_squared;
+        double perpendicular_squared = 0.0;
+        const double precise_radicand = Settle_Pair_Precise_Radicand(
+            r1, r2, pair.constant_r, &perpendicular_squared);
+        const double perpendicular =
+            Settle_Double_Is_Finite_Nonnegative(perpendicular_squared)
+                ? sqrt(perpendicular_squared)
+                : -1.0;
+        controller->Throw_Formatted_SPONGE_Error(
+            spongeErrorSimulationBreakDown, "SETTLE::Do_SETTLE",
+            "Reason:\n\tSETTLE global atoms %d %d cannot produce a finite "
+            "real position-constraint update (target %.9g, perpendicular "
+            "%.17g, radicand float/precise %.9g/%.17g, dt %.9g).\n"
+            "\tReduce the timestep or minimize/equilibrate the input "
+            "state.\n",
+            atom_local[pair.atom_i_serial], atom_local[pair.atom_j_serial],
+            static_cast<double>(pair.constant_r), perpendicular,
+            static_cast<double>(radicand), precise_radicand,
+            static_cast<double>(constrain->dt));
+        return;
+    }
+#endif
 
     Launch_Device_Kernel(
         settle_triangle,

--- a/SPONGE/constrain/settle.cpp
+++ b/SPONGE/constrain/settle.cpp
@@ -703,8 +703,10 @@ static __device__ __host__ __forceinline__ bool
 compute_velocity_constraint_correction_settle(
     const int atom_i, const int atom_j, const VECTOR* crd, const LTMatrix3 cell,
     const LTMatrix3 rcell, const float* mass_inverse, const VECTOR* vel,
-    VECTOR* correction_i, VECTOR* correction_j)
+    VECTOR* correction_i, VECTOR* correction_j, const float relative_tolerance,
+    bool* constraint_violated)
 {
+    if (constraint_violated != NULL) *constraint_violated = false;
     float mass_i_inverse = mass_inverse[atom_i];
     float mass_j_inverse = mass_inverse[atom_j];
     if (mass_i_inverse == 0.0f && mass_j_inverse == 0.0f) return false;
@@ -712,13 +714,27 @@ compute_velocity_constraint_correction_settle(
     VECTOR dr =
         Get_Periodic_Displacement(crd[atom_i], crd[atom_j], cell, rcell);
     float dr2 = dr * dr;
-    if (dr2 < 1e-12f) return false;
+    if (dr2 < 1e-12f)
+    {
+        if (constraint_violated != NULL) *constraint_violated = true;
+        return false;
+    }
 
     VECTOR v_diff = vel[atom_i] - vel[atom_j];
     float denom = (mass_i_inverse + mass_j_inverse) * dr2;
-    if (denom < 1e-20f) return false;
+    if (denom < 1e-20f)
+    {
+        if (constraint_violated != NULL) *constraint_violated = true;
+        return false;
+    }
 
-    float lambda = (dr * v_diff) / denom;
+    const float projection = dr * v_diff;
+    if (constraint_violated != NULL)
+    {
+        const float scale = sqrtf(dr2 * fmaxf(v_diff * v_diff, 1.0e-12f));
+        *constraint_violated = fabsf(projection) > relative_tolerance * scale;
+    }
+    float lambda = projection / denom;
     correction_i[0] = (-mass_i_inverse * lambda) * dr;
     correction_j[0] = (mass_j_inverse * lambda) * dr;
     return true;
@@ -727,7 +743,8 @@ compute_velocity_constraint_correction_settle(
 static __global__ void project_velocity_to_settle_pairs(
     const int pair_numbers, const CONSTRAIN_PAIR* pairs, const VECTOR* crd,
     const LTMatrix3 cell, const LTMatrix3 rcell, const float* mass_inverse,
-    const VECTOR* vel, VECTOR* delta_vel)
+    const VECTOR* vel, VECTOR* delta_vel, const float relative_tolerance,
+    int* violation)
 {
 #ifdef USE_GPU
     int pair_i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -739,9 +756,12 @@ static __global__ void project_velocity_to_settle_pairs(
     {
         CONSTRAIN_PAIR cp = pairs[pair_i];
         VECTOR correction_i, correction_j;
+        bool constraint_violated = false;
         if (compute_velocity_constraint_correction_settle(
                 cp.atom_i_serial, cp.atom_j_serial, crd, cell, rcell,
-                mass_inverse, vel, &correction_i, &correction_j))
+                mass_inverse, vel, &correction_i, &correction_j,
+                relative_tolerance,
+                violation != NULL ? &constraint_violated : NULL))
         {
             atomicAdd(&delta_vel[cp.atom_i_serial].x, correction_i.x);
             atomicAdd(&delta_vel[cp.atom_i_serial].y, correction_i.y);
@@ -750,13 +770,15 @@ static __global__ void project_velocity_to_settle_pairs(
             atomicAdd(&delta_vel[cp.atom_j_serial].y, correction_j.y);
             atomicAdd(&delta_vel[cp.atom_j_serial].z, correction_j.z);
         }
+        if (constraint_violated && violation != NULL) atomicExch(violation, 1);
     }
 }
 
 static __global__ void project_velocity_to_settle_triangles(
     const int triangle_numbers, const CONSTRAIN_TRIANGLE* triangles,
     const VECTOR* crd, const LTMatrix3 cell, const LTMatrix3 rcell,
-    const float* mass_inverse, const VECTOR* vel, VECTOR* delta_vel)
+    const float* mass_inverse, const VECTOR* vel, VECTOR* delta_vel,
+    const float relative_tolerance, int* violation)
 {
 #ifdef USE_GPU
     int tri_i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -768,9 +790,11 @@ static __global__ void project_velocity_to_settle_triangles(
     {
         CONSTRAIN_TRIANGLE tri = triangles[tri_i];
         VECTOR correction_i, correction_j;
+        bool constraint_violated = false;
         if (compute_velocity_constraint_correction_settle(
                 tri.atom_A, tri.atom_B, crd, cell, rcell, mass_inverse, vel,
-                &correction_i, &correction_j))
+                &correction_i, &correction_j, relative_tolerance,
+                violation != NULL ? &constraint_violated : NULL))
         {
             atomicAdd(&delta_vel[tri.atom_A].x, correction_i.x);
             atomicAdd(&delta_vel[tri.atom_A].y, correction_i.y);
@@ -779,9 +803,11 @@ static __global__ void project_velocity_to_settle_triangles(
             atomicAdd(&delta_vel[tri.atom_B].y, correction_j.y);
             atomicAdd(&delta_vel[tri.atom_B].z, correction_j.z);
         }
+        if (constraint_violated && violation != NULL) atomicExch(violation, 1);
         if (compute_velocity_constraint_correction_settle(
                 tri.atom_A, tri.atom_C, crd, cell, rcell, mass_inverse, vel,
-                &correction_i, &correction_j))
+                &correction_i, &correction_j, relative_tolerance,
+                violation != NULL ? &constraint_violated : NULL))
         {
             atomicAdd(&delta_vel[tri.atom_A].x, correction_i.x);
             atomicAdd(&delta_vel[tri.atom_A].y, correction_i.y);
@@ -790,9 +816,11 @@ static __global__ void project_velocity_to_settle_triangles(
             atomicAdd(&delta_vel[tri.atom_C].y, correction_j.y);
             atomicAdd(&delta_vel[tri.atom_C].z, correction_j.z);
         }
+        if (constraint_violated && violation != NULL) atomicExch(violation, 1);
         if (compute_velocity_constraint_correction_settle(
                 tri.atom_B, tri.atom_C, crd, cell, rcell, mass_inverse, vel,
-                &correction_i, &correction_j))
+                &correction_i, &correction_j, relative_tolerance,
+                violation != NULL ? &constraint_violated : NULL))
         {
             atomicAdd(&delta_vel[tri.atom_B].x, correction_i.x);
             atomicAdd(&delta_vel[tri.atom_B].y, correction_i.y);
@@ -801,12 +829,14 @@ static __global__ void project_velocity_to_settle_triangles(
             atomicAdd(&delta_vel[tri.atom_C].y, correction_j.y);
             atomicAdd(&delta_vel[tri.atom_C].z, correction_j.z);
         }
+        if (constraint_violated && violation != NULL) atomicExch(violation, 1);
     }
 }
 
 static __global__ void apply_settle_velocity_correction(
     const int local_atom_numbers, VECTOR* vel, VECTOR* crd,
-    const VECTOR* delta_vel, const float half_dt)
+    const VECTOR* delta_vel, const float velocity_factor,
+    const float coordinate_factor)
 {
 #ifdef USE_GPU
     int atom_i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -816,24 +846,48 @@ static __global__ void apply_settle_velocity_correction(
     for (int atom_i = 0; atom_i < local_atom_numbers; atom_i++)
 #endif
     {
-        VECTOR delta = delta_vel[atom_i];
+        VECTOR delta = velocity_factor * delta_vel[atom_i];
         vel[atom_i] = vel[atom_i] + delta;
-        crd[atom_i] = crd[atom_i] + half_dt * delta;
+        if (coordinate_factor != 0.0f)
+        {
+            crd[atom_i] = crd[atom_i] + coordinate_factor * delta;
+        }
     }
 }
 
-void SETTLE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
+bool SETTLE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
                                                      const float* mass_inverse,
                                                      const LTMatrix3 cell,
-                                                     const LTMatrix3 rcell)
+                                                     const LTMatrix3 rcell,
+                                                     bool update_coordinates)
 {
-    if (!is_initialized || local_atom_numbers <= 0) return;
+    if (!is_initialized || local_atom_numbers <= 0) return true;
     bool has_settle_constraints = num_triangle_local > 0 || num_pair_local > 0;
-    if (!has_settle_constraints) return;
+    if (!has_settle_constraints) return true;
 
-    constexpr int projection_iterations = 8;
+    constexpr int legacy_projection_iterations = 8;
+    constexpr int maximum_velocity_only_iterations = 512;
+    constexpr float relative_tolerance = 1.0e-5f;
+    const int projection_iterations = update_coordinates
+                                          ? legacy_projection_iterations
+                                          : maximum_velocity_only_iterations;
+    // SETTLE extracts disjoint pairs and triangles.  A pair can be projected
+    // directly; a triangle has local constraint degree two, so damping its
+    // parallel Jacobi update by one half is sufficient and does not couple
+    // convergence to unrelated constraints left for SHAKE.
+    const int settle_constraint_degree = num_triangle_local > 0 ? 2 : 1;
+    const float velocity_factor =
+        update_coordinates
+            ? 1.0f
+            : 1.0f / static_cast<float>(settle_constraint_degree);
+    int* d_violation = NULL;
+    if (!update_coordinates &&
+        !Device_Malloc_Safely((void**)&d_violation, sizeof(int)))
+        return false;
+    bool converged = update_coordinates;
     for (int iter = 0; iter < projection_iterations; ++iter)
     {
+        if (!update_coordinates) deviceMemset(d_violation, 0, sizeof(int));
         deviceMemset(d_delta_vel_local, 0, sizeof(VECTOR) * local_atom_numbers);
         if (num_pair_local > 0 && d_pairs_local != NULL)
         {
@@ -843,7 +897,7 @@ void SETTLE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
                     CONTROLLER::device_max_thread,
                 CONTROLLER::device_max_thread, 0, NULL, num_pair_local,
                 d_pairs_local, crd, cell, rcell, mass_inverse, vel,
-                d_delta_vel_local);
+                d_delta_vel_local, relative_tolerance, d_violation);
         }
         if (num_triangle_local > 0 && d_triangles_local != NULL)
         {
@@ -853,15 +907,29 @@ void SETTLE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
                     CONTROLLER::device_max_thread,
                 CONTROLLER::device_max_thread, 0, NULL, num_triangle_local,
                 d_triangles_local, crd, cell, rcell, mass_inverse, vel,
-                d_delta_vel_local);
+                d_delta_vel_local, relative_tolerance, d_violation);
+        }
+        if (!update_coordinates)
+        {
+            int violation = 0;
+            deviceMemcpy(&violation, d_violation, sizeof(int),
+                         deviceMemcpyDeviceToHost);
+            if (violation == 0)
+            {
+                converged = true;
+                break;
+            }
         }
         Launch_Device_Kernel(
             apply_settle_velocity_correction,
             (local_atom_numbers + CONTROLLER::device_max_thread - 1) /
                 CONTROLLER::device_max_thread,
             CONTROLLER::device_max_thread, 0, NULL, local_atom_numbers, vel,
-            crd, d_delta_vel_local, 0.5f * constrain->dt);
+            crd, d_delta_vel_local, velocity_factor,
+            update_coordinates ? 0.5f * constrain->dt : 0.0f);
     }
+    if (d_violation != NULL) deviceFree(d_violation);
+    return converged;
 }
 
 void SETTLE::update_ug_connectivity(CONECT* connectivity)

--- a/SPONGE/constrain/settle.h
+++ b/SPONGE/constrain/settle.h
@@ -43,10 +43,10 @@ struct SETTLE
     void Do_SETTLE(const float* d_mass, VECTOR* crd, const LTMatrix3 cell,
                    const LTMatrix3 rcell, VECTOR* vel, const int need_pressure,
                    LTMatrix3* d_stress);
-    void Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
-                                                 const float* mass_inverse,
-                                                 const LTMatrix3 cell,
-                                                 const LTMatrix3 rcell);
+    bool Project_Velocity_To_Constraint_Manifold(
+        VECTOR* vel, VECTOR* crd, const float* mass_inverse,
+        const LTMatrix3 cell, const LTMatrix3 rcell,
+        bool update_coordinates = true);
 
     int local_atom_numbers = 0;
     int num_triangle_local = 0;

--- a/SPONGE/constrain/settle.h
+++ b/SPONGE/constrain/settle.h
@@ -40,7 +40,8 @@ struct SETTLE
                                    const LTMatrix3 rcell);
 
     LTMatrix3* virial_tensor = NULL;
-    void Do_SETTLE(const float* d_mass, VECTOR* crd, const LTMatrix3 cell,
+    void Do_SETTLE(CONTROLLER* controller, const int* atom_local,
+                   const float* d_mass, VECTOR* crd, const LTMatrix3 cell,
                    const LTMatrix3 rcell, VECTOR* vel, const int need_pressure,
                    LTMatrix3* d_stress);
     void Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,

--- a/SPONGE/constrain/shake.cpp
+++ b/SPONGE/constrain/shake.cpp
@@ -198,8 +198,10 @@ static __device__ __host__ __forceinline__ bool
 compute_velocity_constraint_correction_shake(
     const int atom_i, const int atom_j, const VECTOR* crd, const LTMatrix3 cell,
     const LTMatrix3 rcell, const float* mass_inverse, const VECTOR* vel,
-    VECTOR* correction_i, VECTOR* correction_j)
+    VECTOR* correction_i, VECTOR* correction_j, const float relative_tolerance,
+    bool* constraint_violated)
 {
+    if (constraint_violated != NULL) *constraint_violated = false;
     float mass_i_inverse = mass_inverse[atom_i];
     float mass_j_inverse = mass_inverse[atom_j];
     if (mass_i_inverse == 0.0f && mass_j_inverse == 0.0f) return false;
@@ -207,13 +209,27 @@ compute_velocity_constraint_correction_shake(
     VECTOR dr =
         Get_Periodic_Displacement(crd[atom_i], crd[atom_j], cell, rcell);
     float dr2 = dr * dr;
-    if (dr2 < 1e-12f) return false;
+    if (dr2 < 1e-12f)
+    {
+        if (constraint_violated != NULL) *constraint_violated = true;
+        return false;
+    }
 
     VECTOR v_diff = vel[atom_i] - vel[atom_j];
     float denom = (mass_i_inverse + mass_j_inverse) * dr2;
-    if (denom < 1e-20f) return false;
+    if (denom < 1e-20f)
+    {
+        if (constraint_violated != NULL) *constraint_violated = true;
+        return false;
+    }
 
-    float lambda = (dr * v_diff) / denom;
+    const float projection = dr * v_diff;
+    if (constraint_violated != NULL)
+    {
+        const float scale = sqrtf(dr2 * fmaxf(v_diff * v_diff, 1.0e-12f));
+        *constraint_violated = fabsf(projection) > relative_tolerance * scale;
+    }
+    float lambda = projection / denom;
     correction_i[0] = (-mass_i_inverse * lambda) * dr;
     correction_j[0] = (mass_j_inverse * lambda) * dr;
     return true;
@@ -222,7 +238,8 @@ compute_velocity_constraint_correction_shake(
 static __global__ void project_velocity_to_shake_pairs(
     const int pair_numbers, const CONSTRAIN_PAIR* pairs, const VECTOR* crd,
     const LTMatrix3 cell, const LTMatrix3 rcell, const float* mass_inverse,
-    const VECTOR* vel, VECTOR* delta_vel)
+    const VECTOR* vel, VECTOR* delta_vel, const float relative_tolerance,
+    int* violation)
 {
 #ifdef USE_GPU
     int pair_i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -234,9 +251,12 @@ static __global__ void project_velocity_to_shake_pairs(
     {
         CONSTRAIN_PAIR cp = pairs[pair_i];
         VECTOR correction_i, correction_j;
+        bool constraint_violated = false;
         if (compute_velocity_constraint_correction_shake(
                 cp.atom_i_serial, cp.atom_j_serial, crd, cell, rcell,
-                mass_inverse, vel, &correction_i, &correction_j))
+                mass_inverse, vel, &correction_i, &correction_j,
+                relative_tolerance,
+                violation != NULL ? &constraint_violated : NULL))
         {
             atomicAdd(&delta_vel[cp.atom_i_serial].x, correction_i.x);
             atomicAdd(&delta_vel[cp.atom_i_serial].y, correction_i.y);
@@ -245,12 +265,14 @@ static __global__ void project_velocity_to_shake_pairs(
             atomicAdd(&delta_vel[cp.atom_j_serial].y, correction_j.y);
             atomicAdd(&delta_vel[cp.atom_j_serial].z, correction_j.z);
         }
+        if (constraint_violated && violation != NULL) atomicExch(violation, 1);
     }
 }
 
 static __global__ void apply_shake_velocity_correction(
     const int local_atom_numbers, VECTOR* vel, VECTOR* crd,
-    const VECTOR* delta_vel, const float half_dt)
+    const VECTOR* delta_vel, const float velocity_factor,
+    const float coordinate_factor)
 {
 #ifdef USE_GPU
     int atom_i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -260,25 +282,46 @@ static __global__ void apply_shake_velocity_correction(
     for (int atom_i = 0; atom_i < local_atom_numbers; atom_i++)
 #endif
     {
-        VECTOR delta = delta_vel[atom_i];
+        VECTOR delta = velocity_factor * delta_vel[atom_i];
         vel[atom_i] = vel[atom_i] + delta;
-        crd[atom_i] = crd[atom_i] + half_dt * delta;
+        if (coordinate_factor != 0.0f)
+        {
+            crd[atom_i] = crd[atom_i] + coordinate_factor * delta;
+        }
     }
 }
 
-void SHAKE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
-                                                    const float* mass_inverse,
-                                                    const LTMatrix3 cell,
-                                                    const LTMatrix3 rcell,
-                                                    int local_atom_numbers)
+bool SHAKE::Project_Velocity_To_Constraint_Manifold(
+    VECTOR* vel, VECTOR* crd, const float* mass_inverse, const LTMatrix3 cell,
+    const LTMatrix3 rcell, int local_atom_numbers, bool update_coordinates)
 {
     if (!is_initialized || local_atom_numbers <= 0 ||
         constrain->num_pair_local <= 0)
-        return;
+        return true;
 
-    constexpr int projection_iterations = 8;
+    constexpr int legacy_projection_iterations = 8;
+    constexpr int maximum_velocity_only_iterations = 512;
+    constexpr float relative_tolerance = 1.0e-5f;
+    const int projection_iterations = update_coordinates
+                                          ? legacy_projection_iterations
+                                          : maximum_velocity_only_iterations;
+    // A constraint row overlaps at most 2(d - 1) other rows, so the normalized
+    // pair-overlap matrix has lambda_max <= 2d - 1.  Damping by 1/d therefore
+    // keeps the parallel Richardson/Jacobi update stable.  The degree was
+    // measured before SETTLE pairs were removed, so it is conservative here.
+    const float velocity_factor =
+        update_coordinates
+            ? 1.0f
+            : 1.0f / static_cast<float>(
+                         std::max(1, constrain->maximum_constraint_degree));
+    int* d_violation = NULL;
+    if (!update_coordinates &&
+        !Device_Malloc_Safely((void**)&d_violation, sizeof(int)))
+        return false;
+    bool converged = update_coordinates;
     for (int iter = 0; iter < projection_iterations; ++iter)
     {
+        if (!update_coordinates) deviceMemset(d_violation, 0, sizeof(int));
         deviceMemset(constrain_frc, 0, sizeof(VECTOR) * local_atom_numbers);
         Launch_Device_Kernel(
             project_velocity_to_shake_pairs,
@@ -286,14 +329,28 @@ void SHAKE::Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
                 CONTROLLER::device_max_thread,
             CONTROLLER::device_max_thread, 0, NULL, constrain->num_pair_local,
             constrain->constrain_pair_local, crd, cell, rcell, mass_inverse,
-            vel, constrain_frc);
+            vel, constrain_frc, relative_tolerance, d_violation);
+        if (!update_coordinates)
+        {
+            int violation = 0;
+            deviceMemcpy(&violation, d_violation, sizeof(int),
+                         deviceMemcpyDeviceToHost);
+            if (violation == 0)
+            {
+                converged = true;
+                break;
+            }
+        }
         Launch_Device_Kernel(
             apply_shake_velocity_correction,
             (local_atom_numbers + CONTROLLER::device_max_thread - 1) /
                 CONTROLLER::device_max_thread,
             CONTROLLER::device_max_thread, 0, NULL, local_atom_numbers, vel,
-            crd, constrain_frc, 0.5f * constrain->dt);
+            crd, constrain_frc, velocity_factor,
+            update_coordinates ? 0.5f * constrain->dt : 0.0f);
     }
+    if (d_violation != NULL) deviceFree(d_violation);
+    return converged;
 }
 
 static __global__ void Constrain_Force_Cycle_With_Virial(

--- a/SPONGE/constrain/shake.cpp
+++ b/SPONGE/constrain/shake.cpp
@@ -1,5 +1,7 @@
 ﻿#include "shake.h"
 
+#include "velocity_projection.h"
+
 static __global__ void Constrain_Force_Cycle(
     const int constrain_pair_numbers, const VECTOR* crd, const LTMatrix3 cell,
     const LTMatrix3 rcell, const CONSTRAIN_PAIR* constrain_pair,
@@ -215,7 +217,9 @@ compute_velocity_constraint_correction_shake(
         return false;
     }
 
-    VECTOR v_diff = vel[atom_i] - vel[atom_j];
+    const VECTOR velocity_i = vel[atom_i];
+    const VECTOR velocity_j = vel[atom_j];
+    VECTOR v_diff = velocity_i - velocity_j;
     float denom = (mass_i_inverse + mass_j_inverse) * dr2;
     if (denom < 1e-20f)
     {
@@ -226,8 +230,9 @@ compute_velocity_constraint_correction_shake(
     const float projection = dr * v_diff;
     if (constraint_violated != NULL)
     {
-        const float scale = sqrtf(dr2 * fmaxf(v_diff * v_diff, 1.0e-12f));
-        *constraint_violated = fabsf(projection) > relative_tolerance * scale;
+        const float tolerance = Velocity_Constraint_Residual_Tolerance(
+            dr2, velocity_i, velocity_j, v_diff, relative_tolerance);
+        *constraint_violated = fabsf(projection) > tolerance;
     }
     float lambda = projection / denom;
     correction_i[0] = (-mass_i_inverse * lambda) * dr;

--- a/SPONGE/constrain/shake.h
+++ b/SPONGE/constrain/shake.h
@@ -36,11 +36,10 @@ struct SHAKE
     void Remember_Last_Coordinates(const VECTOR* crd, const LTMatrix3 cell,
                                    const LTMatrix3 rcell);
     // 将速度投影到SHAKE约束流形
-    void Project_Velocity_To_Constraint_Manifold(VECTOR* vel, VECTOR* crd,
-                                                 const float* mass_inverse,
-                                                 const LTMatrix3 cell,
-                                                 const LTMatrix3 rcell,
-                                                 int local_atom_numbers);
+    bool Project_Velocity_To_Constraint_Manifold(
+        VECTOR* vel, VECTOR* crd, const float* mass_inverse,
+        const LTMatrix3 cell, const LTMatrix3 rcell, int local_atom_numbers,
+        bool update_coordinates = true);
     // 进行约束迭代
     void Constrain(int atom_numbers, VECTOR* crd, VECTOR* vel,
                    const float* mass_inverse, const float* d_mass,

--- a/SPONGE/constrain/velocity_projection.h
+++ b/SPONGE/constrain/velocity_projection.h
@@ -1,0 +1,26 @@
+﻿#pragma once
+
+#include <cfloat>
+
+#include "../common.h"
+
+// A relative residual alone is unattainable when two stored float velocities
+// are nearly equal.  Bound the subtraction and three-component dot-product
+// roundoff by the scale of the operands that are actually represented.
+static __device__ __host__ __forceinline__ float
+Velocity_Constraint_Residual_Tolerance(const float displacement_squared,
+                                       const VECTOR velocity_i,
+                                       const VECTOR velocity_j,
+                                       const VECTOR velocity_difference,
+                                       const float relative_tolerance)
+{
+    const float displacement_norm = sqrtf(displacement_squared);
+    const float relative_scale =
+        displacement_norm *
+        sqrtf(fmaxf(velocity_difference * velocity_difference, 1.0e-12f));
+    const float velocity_scale =
+        fmaxf(sqrtf(velocity_i * velocity_i), sqrtf(velocity_j * velocity_j));
+    const float roundoff_floor =
+        8.0f * FLT_EPSILON * displacement_norm * velocity_scale;
+    return fmaxf(relative_tolerance * relative_scale, roundoff_floor);
+}

--- a/SPONGE/main.cpp
+++ b/SPONGE/main.cpp
@@ -1783,9 +1783,9 @@ void Main_Iteration()
                                            md_info.sys.freedom);
             }
 
-            settle.Do_SETTLE(dd.d_mass, dd.crd, md_info.pbc.cell,
-                             md_info.pbc.rcell, dd.vel, md_info.need_pressure,
-                             md_info.sys.d_stress);
+            settle.Do_SETTLE(&controller, dd.atom_local, dd.d_mass, dd.crd,
+                             md_info.pbc.cell, md_info.pbc.rcell, dd.vel,
+                             md_info.need_pressure, md_info.sys.d_stress);
             shake.Constrain(dd.atom_numbers, dd.crd, dd.vel, dd.d_mass_inverse,
                             dd.d_mass, md_info.pbc.cell, md_info.pbc.rcell,
                             md_info.need_pressure, md_info.sys.d_stress);

--- a/SPONGE/neighbor_list/neighbor_list.cpp
+++ b/SPONGE/neighbor_list/neighbor_list.cpp
@@ -1,6 +1,77 @@
 ﻿#include "neighbor_list.h"
 
+#include <cstdint>
+
 #define MAX_GRID_NEIGHBORS 192
+
+// 按 grid_j 升序逐个检查 27 种周期镜像位移，命中即记录，输出为升序邻居表。
+static __host__ __device__ __forceinline__ int Find_Neighbor_Grids_Scan(
+    int grid_i, int Nx, int Ny, int Nz, int64_t dxy, int64_t dxz, int64_t dyz,
+    LTMatrix3 cell, int* neighbor_i)
+{
+    const int64_t NyNz = static_cast<int64_t>(Ny) * Nz;
+    int local = 0;
+    int dx, dy, dz;
+    const int64_t grid_i_x = grid_i / NyNz;
+    const int64_t grid_i_y = (grid_i % NyNz) / Nz;
+    const int64_t grid_i_z = grid_i % Nz;
+    int cx, cy;
+    int grid_j = 0;
+    for (int64_t grid_j_x = 0; grid_j_x < Nx; grid_j_x += 1)
+    {
+        const int64_t base_x = grid_i_x - grid_j_x;
+        for (int64_t grid_j_y = 0; grid_j_y < Ny; grid_j_y += 1)
+        {
+            const int64_t base_y = grid_i_y - grid_j_y;
+            for (int64_t grid_j_z = 0; grid_j_z < Nz;
+                 grid_j_z += 1, grid_j += 1)
+            {
+                const int64_t base_z = grid_i_z - grid_j_z;
+                for (int k = 0; k < 27; k += 1)
+                {
+                    dx = k / 9 - 1;
+                    dy = (k % 9) / 3 - 1;
+                    dz = k % 3 - 1;
+                    const int64_t temp_x = base_x +
+                                           static_cast<int64_t>(dx) * Nx +
+                                           dy * dxy + dz * dxz;
+                    const int64_t temp_y =
+                        base_y + static_cast<int64_t>(dy) * Ny + dz * dyz;
+                    const int64_t temp_z =
+                        base_z + static_cast<int64_t>(dz) * Nz;
+                    cx = static_cast<double>(dy) * cell.a21 +
+                                     static_cast<double>(dz) * cell.a31 ==
+                                 0.0
+                             ? -2
+                             : -3;
+                    cy = static_cast<double>(dz) * cell.a32 == 0.0 ? -2 : -3;
+                    if (temp_x <= 2 && temp_x >= cx && temp_y <= 2 &&
+                        temp_y >= cy && temp_z <= 2 && temp_z >= -2)
+                    {
+                        if (local >= MAX_GRID_NEIGHBORS)
+                        {
+                            local = -1;
+                        }
+                        else
+                        {
+                            neighbor_i[local++] = grid_j;
+                        }
+                        break;
+                    }
+                }
+                if (local < 0) break;
+            }
+            if (local < 0) break;
+        }
+        if (local < 0) break;
+    }
+    return local;
+}
+
+#ifdef GPU_ARCH_NAME
+// 枚举路径单线程候选上限；超出即回退到全扫描，语义不变
+#define GRID_ENUM_CAPACITY 2048
+#endif
 
 static __global__ void Find_Neighor_Grids_Device(
     int grid_numbers, int* neighbor_grid_numbers, int* neighbor_grids, int Nx,
@@ -8,42 +79,108 @@ static __global__ void Find_Neighor_Grids_Device(
 {
     SIMPLE_DEVICE_FOR(grid_i, grid_numbers)
     {
-        int NyNz = Ny * Nz;
+        const int64_t dxy = static_cast<int64_t>(cell.a21 / grid_length);
+        const int64_t dxz = static_cast<int64_t>(cell.a31 / grid_length);
+        const int64_t dyz = static_cast<int64_t>(cell.a32 / grid_length);
+        int* neighbor_i = neighbor_grids + (size_t)MAX_GRID_NEIGHBORS * grid_i;
         int local = 0;
-        int dx, dy, dz;
-        int* neighbor_i = neighbor_grids + MAX_GRID_NEIGHBORS * grid_i;
-        INT_VECTOR grid_i_xyz = {grid_i / NyNz, (grid_i % NyNz) / Nz,
-                                 grid_i % Nz};
-        INT_VECTOR grid_j_xyz, temp_delta;
-        int dxy = cell.a21 / grid_length;
-        int dxz = cell.a31 / grid_length;
-        int dyz = cell.a32 / grid_length;
-        int cx, cy;
-        for (int grid_j = 0; grid_j < grid_numbers; grid_j += 1)
+#ifdef GPU_ARCH_NAME
+        // 全扫描是 O(grid_numbers^2)。命中条件对每种周期镜像 (dx,dy,dz)
+        // 都是关于 grid_j 三个分量的区间约束，因此可以按镜像直接枚举候选
+        // 小盒，再排序去重得到与全扫描逐位一致的升序邻居表。
+        const int64_t grid_i_x = grid_i / (static_cast<int64_t>(Ny) * Nz);
+        const int64_t grid_i_y =
+            (grid_i % (static_cast<int64_t>(Ny) * Nz)) / Nz;
+        const int64_t grid_i_z = grid_i % Nz;
+        int candidates[GRID_ENUM_CAPACITY];
+        int candidate_numbers = 0;
+        bool enumeration_ok = true;
+        for (int k = 0; k < 27 && enumeration_ok; k += 1)
         {
-            grid_j_xyz = {grid_j / NyNz, (grid_j % NyNz) / Nz, grid_j % Nz};
-            for (int k = 0; k < 27; k += 1)
+            const int dx = k / 9 - 1;
+            const int dy = (k % 9) / 3 - 1;
+            const int dz = k % 3 - 1;
+            const int cx = static_cast<double>(dy) * cell.a21 +
+                                       static_cast<double>(dz) * cell.a31 ==
+                                   0.0
+                               ? -2
+                               : -3;
+            const int cy = static_cast<double>(dz) * cell.a32 == 0.0 ? -2 : -3;
+            const int64_t shift_x =
+                static_cast<int64_t>(dx) * Nx + dy * dxy + dz * dxz;
+            const int64_t shift_y = static_cast<int64_t>(dy) * Ny + dz * dyz;
+            const int64_t shift_z = static_cast<int64_t>(dz) * Nz;
+            const int64_t lo_x =
+                grid_i_x + shift_x - 2 > 0 ? grid_i_x + shift_x - 2 : 0;
+            const int64_t hi_x = grid_i_x + shift_x - cx < Nx - 1
+                                     ? grid_i_x + shift_x - cx
+                                     : Nx - 1;
+            const int64_t lo_y =
+                grid_i_y + shift_y - 2 > 0 ? grid_i_y + shift_y - 2 : 0;
+            const int64_t hi_y = grid_i_y + shift_y - cy < Ny - 1
+                                     ? grid_i_y + shift_y - cy
+                                     : Ny - 1;
+            const int64_t lo_z =
+                grid_i_z + shift_z - 2 > 0 ? grid_i_z + shift_z - 2 : 0;
+            const int64_t hi_z = grid_i_z + shift_z + 2 < Nz - 1
+                                     ? grid_i_z + shift_z + 2
+                                     : Nz - 1;
+            if (lo_x > hi_x || lo_y > hi_y || lo_z > hi_z) continue;
+            const int64_t box =
+                (hi_x - lo_x + 1) * (hi_y - lo_y + 1) * (hi_z - lo_z + 1);
+            if (candidate_numbers + box > GRID_ENUM_CAPACITY)
             {
-                dx = k / 9 - 1;
-                dy = (k % 9) / 3 - 1;
-                dz = k % 3 - 1;
-                temp_delta = {
-                    grid_i_xyz.int_x + dx * Nx + dy * dxy + dz * dxz -
-                        grid_j_xyz.int_x,
-                    grid_i_xyz.int_y + dy * Ny + dz * dyz - grid_j_xyz.int_y,
-                    grid_i_xyz.int_z + dz * Nz - grid_j_xyz.int_z};
-                cx = dy * cell.a21 + dz * cell.a31 == 0 ? -2 : -3;
-                cy = dz * cell.a32 == 0 ? -2 : -3;
-                if (temp_delta.int_x <= 2 && temp_delta.int_x >= cx &&
-                    temp_delta.int_y <= 2 && temp_delta.int_y >= cy &&
-                    temp_delta.int_z <= 2 && temp_delta.int_z >= -2)
+                enumeration_ok = false;
+                break;
+            }
+            for (int64_t jx = lo_x; jx <= hi_x; jx += 1)
+            {
+                for (int64_t jy = lo_y; jy <= hi_y; jy += 1)
                 {
-                    neighbor_i[local] = grid_j;
-                    local += 1;
-                    break;
+                    for (int64_t jz = lo_z; jz <= hi_z; jz += 1)
+                    {
+                        candidates[candidate_numbers] =
+                            static_cast<int>((jx * Ny + jy) * Nz + jz);
+                        candidate_numbers += 1;
+                    }
                 }
             }
         }
+        if (enumeration_ok)
+        {
+            for (int gap = candidate_numbers / 2; gap > 0; gap /= 2)
+            {
+                for (int i = gap; i < candidate_numbers; i += 1)
+                {
+                    const int value = candidates[i];
+                    int j = i;
+                    for (; j >= gap && candidates[j - gap] > value; j -= gap)
+                    {
+                        candidates[j] = candidates[j - gap];
+                    }
+                    candidates[j] = value;
+                }
+            }
+            for (int i = 0; i < candidate_numbers; i += 1)
+            {
+                if (i > 0 && candidates[i] == candidates[i - 1]) continue;
+                if (local >= MAX_GRID_NEIGHBORS)
+                {
+                    local = -1;
+                    break;
+                }
+                neighbor_i[local++] = candidates[i];
+            }
+        }
+        else
+        {
+            local = Find_Neighbor_Grids_Scan(grid_i, Nx, Ny, Nz, dxy, dxz, dyz,
+                                             cell, neighbor_i);
+        }
+#else
+        local = Find_Neighbor_Grids_Scan(grid_i, Nx, Ny, Nz, dxy, dxz, dyz,
+                                         cell, neighbor_i);
+#endif
         neighbor_grid_numbers[grid_i] = local;
     }
 }

--- a/SPONGE/xponge/load/gromacs.hpp
+++ b/SPONGE/xponge/load/gromacs.hpp
@@ -164,6 +164,7 @@ struct Gromacs_Molecule
     std::vector<Gromacs_Dihedral> dihedrals;
     std::vector<Gromacs_Settle> settles;
     std::vector<Gromacs_Constraint> constraints;
+    std::set<std::pair<int, int>> exclusions;
     std::vector<Gromacs_CMap> cmaps;
 };
 
@@ -184,6 +185,13 @@ struct Gromacs_Topology
     std::vector<Gromacs_CMap_Type> cmap_types;
     std::unordered_map<std::string, Gromacs_Molecule> molecules;
     std::vector<std::pair<std::string, int>> system_molecules;
+};
+
+struct Gromacs_Source_Line
+{
+    std::string text;
+    fs::path file_path;
+    std::size_t line_number = 0;
 };
 
 static std::string Gromacs_Trim(const std::string& value)
@@ -279,7 +287,7 @@ static fs::path Gromacs_Resolve_Include(
 static void Gromacs_Preprocess_File(const fs::path& file_path,
                                     std::set<std::string>* macros,
                                     const std::vector<fs::path>& include_dirs,
-                                    std::vector<std::string>* lines,
+                                    std::vector<Gromacs_Source_Line>* lines,
                                     CONTROLLER* controller,
                                     const char* error_by)
 {
@@ -311,8 +319,11 @@ static void Gromacs_Preprocess_File(const fs::path& file_path,
 
     std::string raw_line;
     std::string continued_line;
+    std::size_t line_number = 0;
     while (std::getline(fin, raw_line))
     {
+        line_number++;
+        std::size_t logical_line_number = line_number;
         std::string line = Gromacs_Trim(raw_line);
         if (!line.empty() && line[0] == '#')
         {
@@ -425,6 +436,7 @@ static void Gromacs_Preprocess_File(const fs::path& file_path,
                     spongeErrorBadFileFormat, error_by,
                     "Reason:\n\tunterminated GROMACS line continuation\n");
             }
+            line_number++;
             std::string next_line =
                 Gromacs_Strip_Comment(Gromacs_Trim(raw_line));
             if (!next_line.empty())
@@ -435,7 +447,7 @@ static void Gromacs_Preprocess_File(const fs::path& file_path,
         }
         if (!continued_line.empty())
         {
-            lines->push_back(continued_line);
+            lines->push_back({continued_line, file_path, logical_line_number});
             continued_line.clear();
         }
     }
@@ -446,6 +458,23 @@ static void Gromacs_Preprocess_File(const fs::path& file_path,
             spongeErrorBadFileFormat, error_by,
             "Reason:\n\tunterminated GROMACS preprocessor conditional\n");
     }
+}
+
+static bool Gromacs_Is_Parsed_Section(const std::string& section)
+{
+    static const std::set<std::string> parsed_sections = {
+        "defaults",      "atomtypes", "bondtypes",      "angletypes",
+        "dihedraltypes", "pairtypes", "nonbond_params", "cmaptypes",
+        "moleculetype",  "atoms",     "bonds",          "pairs",
+        "angles",        "dihedrals", "settles",        "constraints",
+        "exclusions",    "cmap",      "molecules"};
+    return parsed_sections.count(section) > 0;
+}
+
+static bool Gromacs_Is_Ignored_Metadata_Section(const std::string& section)
+{
+    static const std::set<std::string> ignored_metadata_sections = {"system"};
+    return ignored_metadata_sections.count(section) > 0;
 }
 
 static float Gromacs_To_Kcal(float value_in_kj) { return value_in_kj / 4.184f; }
@@ -699,7 +728,7 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
         }
     }
 
-    std::vector<std::string> lines;
+    std::vector<Gromacs_Source_Line> lines;
     Gromacs_Preprocess_File(top_path, &macros, include_dirs, &lines, controller,
                             error_by);
 
@@ -707,11 +736,23 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
     std::string current_section;
     Gromacs_Molecule* current_molecule = NULL;
 
-    for (const std::string& line : lines)
+    for (const Gromacs_Source_Line& source_line : lines)
     {
+        const std::string& line = source_line.text;
         if (line.front() == '[' && line.back() == ']')
         {
             current_section = Gromacs_Trim(line.substr(1, line.size() - 2));
+            if (!Gromacs_Is_Parsed_Section(current_section) &&
+                !Gromacs_Is_Ignored_Metadata_Section(current_section))
+            {
+                std::string reason =
+                    "Reason:\n\tunsupported GROMACS topology section [ " +
+                    current_section + " ] at " +
+                    source_line.file_path.string() + ":" +
+                    std::to_string(source_line.line_number) + "\n";
+                controller->Throw_SPONGE_Error(spongeErrorBadFileFormat,
+                                               error_by, reason.c_str());
+            }
             continue;
         }
 
@@ -1078,6 +1119,33 @@ static Gromacs_Topology Gromacs_Parse_Topology(CONTROLLER* controller)
             }
             current_molecule->constraints.push_back(constraint);
         }
+        else if (current_section == "exclusions")
+        {
+            if (current_molecule == NULL || tokens.size() < 2)
+            {
+                controller->Throw_SPONGE_Error(
+                    spongeErrorBadFileFormat, error_by,
+                    "Reason:\n\tinvalid [ exclusions ] entry in GROMACS "
+                    "topology\n");
+            }
+            int atom_i = std::stoi(tokens[0]) - 1;
+            for (std::size_t i = 1; i < tokens.size(); i++)
+            {
+                int atom_j = std::stoi(tokens[i]) - 1;
+                if (atom_i < 0 || atom_j < 0 || atom_i == atom_j ||
+                    atom_i >=
+                        static_cast<int>(current_molecule->atoms.size()) ||
+                    atom_j >= static_cast<int>(current_molecule->atoms.size()))
+                {
+                    controller->Throw_SPONGE_Error(
+                        spongeErrorBadFileFormat, error_by,
+                        "Reason:\n\tinvalid atom pair in GROMACS [ exclusions "
+                        "]\n");
+                }
+                current_molecule->exclusions.insert(
+                    {std::min(atom_i, atom_j), std::max(atom_i, atom_j)});
+            }
+        }
         else if (current_section == "cmap")
         {
             if (current_molecule == NULL || tokens.size() < 6)
@@ -1380,6 +1448,13 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                 }
             };
 
+            std::set<std::pair<int, int>> exclusion_pairs = molecule.exclusions;
+            for (const std::pair<int, int>& exclusion : exclusion_pairs)
+            {
+                require_local_atom(exclusion.first);
+                require_local_atom(exclusion.second);
+            }
+
             auto append_bond =
                 [&](int ai_local, int aj_local, float k, float r0)
             {
@@ -1501,10 +1576,15 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                 {
                     if (distance[j] > 0 && distance[j] <= molecule.nrexcl)
                     {
-                        system->exclusions.excluded_atoms[local_to_global[i]]
-                            .push_back(local_to_global[j]);
+                        exclusion_pairs.insert({i, j});
                     }
                 }
+            }
+            for (const std::pair<int, int>& exclusion : exclusion_pairs)
+            {
+                system->exclusions
+                    .excluded_atoms[local_to_global[exclusion.first]]
+                    .push_back(local_to_global[exclusion.second]);
             }
 
             for (const Gromacs_CMap& cmap_item : molecule.cmaps)

--- a/SPONGE/xponge/load/gromacs.hpp
+++ b/SPONGE/xponge/load/gromacs.hpp
@@ -1290,6 +1290,7 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
 
     std::vector<std::string> global_atom_types;
     std::vector<std::vector<int>> molecule_local_to_global;
+    std::size_t pairs_overridden_by_exclusions = 0;
 
     for (const auto& item : topology.system_molecules)
     {
@@ -1762,6 +1763,14 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
             {
                 int ai_local = pair.ai - 1;
                 int aj_local = pair.aj - 1;
+                // GROMACS semantics: an explicit [ exclusions ] entry removes
+                // the special 1-4 interaction from [ pairs ] entirely.
+                if (molecule.exclusions.count({std::min(ai_local, aj_local),
+                                               std::max(ai_local, aj_local)}))
+                {
+                    pairs_overridden_by_exclusions += 1;
+                    continue;
+                }
                 const Gromacs_Molecule_Atom& atom_i = molecule.atoms[ai_local];
                 const Gromacs_Molecule_Atom& atom_j = molecule.atoms[aj_local];
                 std::pair<float, float> c6_c12{0.0f, 0.0f};
@@ -1803,6 +1812,13 @@ static void Gromacs_Instantiate_System(const Gromacs_Topology& topology,
                 nb14.cf_scale_factor.push_back(topology.defaults.fudge_qq);
             }
         }
+    }
+    if (pairs_overridden_by_exclusions > 0)
+    {
+        controller->printf(
+            "WARNING: %llu GROMACS [ pairs ] interaction(s) overridden by "
+            "explicit [ exclusions ]\n",
+            static_cast<unsigned long long>(pairs_overridden_by_exclusions));
     }
 }
 

--- a/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_section_integrity.py
+++ b/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_section_integrity.py
@@ -202,3 +202,74 @@ def test_explicit_exclusions_are_normalized_and_merged_with_nrexcl(tmp_path):
     assert _extract_mdout_term(with_mdout, "LJ_short") == pytest.approx(
         expected_at_0_7_nm, abs=0.011
     )
+
+
+def test_explicit_exclusions_override_pairs_14_interaction(tmp_path):
+    topology = """
+        [ defaults ]
+        1 2 yes 0.25 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.20 0.4184
+        B B 12.0 0.0 A 0.20 0.4184
+
+        [ nonbond_params ]
+        A B 1 0.40 4.184
+
+        [ moleculetype ]
+        PAIR 1
+
+        [ atoms ]
+        1 A 1 PAIR A 1 0.0 12.0
+        2 B 1 PAIR B 2 0.0 12.0
+
+        [ bonds ]
+        1 2 1 0.50 0.0
+
+        [ pairs ]
+        1 2 1
+
+        {exclusions}
+
+        [ system ]
+        explicit exclusions override pairs
+
+        [ molecules ]
+        PAIR 1
+    """
+    atoms = (("A", 0.0), ("B", 0.5))
+    without_result, without_mdout = _run_topology(
+        tmp_path / "without",
+        topology.format(exclusions=""),
+        atoms=atoms,
+    )
+    with_result, with_mdout = _run_topology(
+        tmp_path / "with",
+        topology.format(
+            exclusions="""
+            [ exclusions ]
+            1 2
+            """
+        ),
+        atoms=atoms,
+    )
+
+    assert without_result.returncode == 0, (
+        without_result.stdout + "\n" + without_result.stderr
+    )
+    sigma_over_r = 0.40 / 0.5
+    expected_pair_14 = 0.25 * 4.0 * (sigma_over_r**12 - sigma_over_r**6)
+    assert _extract_mdout_term(without_mdout, "nb14_LJ") == pytest.approx(
+        expected_pair_14, abs=0.011
+    )
+    assert with_result.returncode == 0, (
+        with_result.stdout + "\n" + with_result.stderr
+    )
+    # The nb14 columns disappear entirely once every pair is overridden.
+    with_lines = with_mdout.read_text().splitlines()
+    with_terms = dict(zip(with_lines[0].split(), with_lines[1].split()))
+    assert float(with_terms.get("nb14_LJ", 0.0)) == pytest.approx(
+        0.0, abs=0.011
+    )
+    output = with_result.stdout + "\n" + with_result.stderr
+    assert "overridden by explicit [ exclusions ]" in output

--- a/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_section_integrity.py
+++ b/benchmarks/comparison/tests/gromacs/tests/comp_direct_topgro_section_integrity.py
@@ -1,0 +1,204 @@
+import json
+import os
+import subprocess
+import textwrap
+
+import pytest
+
+
+def _toml_string(value):
+    return json.dumps(os.fspath(value))
+
+
+def _gro_atom(resid, resname, atomname, atomnr, x):
+    return (
+        f"{resid:5d}{resname:<5}{atomname:>5}{atomnr:5d}"
+        f"{x:8.3f}{0.0:8.3f}{0.0:8.3f}"
+    )
+
+
+def _minimal_topology(injected="", system_text="section integrity test"):
+    return f"""
+        [ defaults ]
+        1 2 yes 1.0 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.30 0.4184
+
+        {injected}
+
+        [ moleculetype ]
+        ONE 0
+
+        [ atoms ]
+        1 A 1 ONE A 1 0.0 12.0
+
+        [ system ]
+        {system_text}
+
+        [ molecules ]
+        ONE 1
+    """
+
+
+def _run_topology(tmp_path, topology, atoms=(("A", 0.0),)):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    top_path = tmp_path / "topol.top"
+    gro_path = tmp_path / "conf.gro"
+    mdin_path = tmp_path / "mdin.spg.toml"
+    mdout_path = tmp_path / "mdout.txt"
+
+    top_path.write_text(textwrap.dedent(topology).strip() + "\n")
+    atom_lines = [
+        _gro_atom(1, "ONE", atom_name, index + 1, x)
+        for index, (atom_name, x) in enumerate(atoms)
+    ]
+    gro_path.write_text(
+        "\n".join(
+            [
+                "section integrity test",
+                str(len(atom_lines)),
+                *atom_lines,
+                "   5.00000   5.00000   5.00000",
+            ]
+        )
+        + "\n"
+    )
+    mdin_path.write_text(
+        textwrap.dedent(
+            f"""
+            md_name = "direct_gromacs_section_integrity"
+            mode = "nve"
+            step_limit = 0
+            dt = 0
+            cutoff = 8.0
+            gromacs_top = {_toml_string(top_path)}
+            gromacs_gro = {_toml_string(gro_path)}
+            mdout = {_toml_string(mdout_path)}
+            print_zeroth_frame = 1
+            write_mdout_interval = 1
+            """
+        ).strip()
+        + "\n"
+    )
+
+    result = subprocess.run(
+        [os.environ.get("SPONGE_BIN", "SPONGE"), "-mdin", str(mdin_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    return result, mdout_path
+
+
+def _extract_mdout_term(mdout_path, term_name):
+    lines = mdout_path.read_text().splitlines()
+    headers = lines[0].split()
+    values = lines[1].split()
+    assert len(headers) == len(values)
+    return float(dict(zip(headers, values))[term_name])
+
+
+def test_active_unsupported_section_in_include_reports_source_line(tmp_path):
+    include_path = tmp_path / "unsupported.itp"
+    include_path.write_text("; metadata\n\n[ virtual_sites2 \\\n]\n1 1 1 0.5\n")
+
+    result, _ = _run_topology(
+        tmp_path,
+        _minimal_topology('#include "unsupported.itp"'),
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode != 0
+    assert "spongeErrorBadFileFormat" in output
+    assert "unsupported GROMACS topology section [ virtual_sites2 ]" in output
+    assert f"{include_path}:3" in output
+
+
+def test_unsupported_section_in_inactive_branch_is_not_parsed(tmp_path):
+    result, _ = _run_topology(
+        tmp_path,
+        _minimal_topology(
+            """
+            #ifdef NEVER_DEFINED
+            [ virtual_sites2 ]
+            #endif
+            """
+        ),
+    )
+
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0, output
+    assert "unsupported GROMACS topology section" not in output
+
+
+def test_system_metadata_section_is_explicitly_allowed(tmp_path):
+    result, _ = _run_topology(
+        tmp_path,
+        _minimal_topology(system_text="arbitrary human-readable system name"),
+    )
+
+    assert result.returncode == 0, result.stdout + "\n" + result.stderr
+
+
+def test_explicit_exclusions_are_normalized_and_merged_with_nrexcl(tmp_path):
+    topology = """
+        [ defaults ]
+        1 2 yes 1.0 1.0
+
+        [ atomtypes ]
+        A A 12.0 0.0 A 0.30 4.184
+
+        [ moleculetype ]
+        TRIPLE 1
+
+        [ atoms ]
+        1 A 1 TRIPLE A1 1 0.0 12.0
+        2 A 1 TRIPLE A2 2 0.0 12.0
+        3 A 1 TRIPLE A3 3 0.0 12.0
+
+        [ bonds ]
+        1 2 1 0.35 0.0
+
+        {exclusions}
+
+        [ system ]
+        explicit exclusions
+
+        [ molecules ]
+        TRIPLE 1
+    """
+    atoms = (("A1", 0.0), ("A2", 0.35), ("A3", 0.7))
+    without_result, without_mdout = _run_topology(
+        tmp_path / "without",
+        topology.format(exclusions=""),
+        atoms=atoms,
+    )
+    with_result, with_mdout = _run_topology(
+        tmp_path / "with",
+        topology.format(
+            exclusions="""
+            [ exclusions ]
+            2 3 3
+            3 2
+            """
+        ),
+        atoms=atoms,
+    )
+
+    assert without_result.returncode == 0, (
+        without_result.stdout + "\n" + without_result.stderr
+    )
+    assert with_result.returncode == 0, (
+        with_result.stdout + "\n" + with_result.stderr
+    )
+    expected_at_0_35_nm = 4.0 * ((0.30 / 0.35) ** 12 - (0.30 / 0.35) ** 6)
+    expected_at_0_7_nm = 4.0 * ((0.30 / 0.7) ** 12 - (0.30 / 0.7) ** 6)
+    assert _extract_mdout_term(without_mdout, "LJ_short") == pytest.approx(
+        expected_at_0_35_nm + expected_at_0_7_nm, abs=0.011
+    )
+    assert _extract_mdout_term(with_mdout, "LJ_short") == pytest.approx(
+        expected_at_0_7_nm, abs=0.011
+    )

--- a/benchmarks/validation/misc/tests/constraint_velocity_projection_probe.cpp
+++ b/benchmarks/validation/misc/tests/constraint_velocity_projection_probe.cpp
@@ -1,4 +1,5 @@
-﻿#include <cmath>
+﻿#include <cfloat>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 
@@ -25,6 +26,19 @@ const VECTOR kVelocities[kAtomCount] = {
 };
 const float kMassInverse[kAtomCount] = {1.0f / 16.0f, 1.0f, 1.0f};
 const int kPairs[kPairCount][2] = {{0, 1}, {0, 2}, {1, 2}};
+
+const VECTOR kRoundoffCoordinates[kAtomCount] = {
+    {0.0f, 0.0f, 0.0f},
+    {0.5699996948242188f, 0.779998779296875f, -0.25f},
+    {-0.5999984741210938f, 0.26000213623046875f, 0.7599983215332031f},
+};
+const VECTOR kRoundoffVelocities[kAtomCount] = {
+    {-0.174088716506958f, -0.10837503522634506f, 0.24693767726421356f},
+    {-1.4800273180007935f, 1.8255033493041992f, 0.039367739111185074f},
+    {-0.05815054848790169f, 1.55351984500885f, -1.609876275062561f},
+};
+const float kRoundoffMassInverse[kAtomCount] = {1.0f / 15.9994f, 1.0f / 1.008f,
+                                                1.0f / 1.008f};
 
 bool Fail(const char* message)
 {
@@ -70,6 +84,50 @@ bool Check_Velocity_Only_Result(const char* name,
     return true;
 }
 
+bool Check_Roundoff_Floor_Result(const char* name,
+                                 const VECTOR* original_coordinates,
+                                 const VECTOR* projected_coordinates,
+                                 const VECTOR* projected_velocities)
+{
+    if (std::memcmp(original_coordinates, projected_coordinates,
+                    sizeof(kRoundoffCoordinates)) != 0)
+        return Fail("roundoff-floor projection changed coordinates");
+
+    bool exercised_roundoff_floor = false;
+    for (const auto& pair : kPairs)
+    {
+        const VECTOR displacement =
+            projected_coordinates[pair[0]] - projected_coordinates[pair[1]];
+        const VECTOR velocity_i = projected_velocities[pair[0]];
+        const VECTOR velocity_j = projected_velocities[pair[1]];
+        const VECTOR velocity_difference = velocity_i - velocity_j;
+        const float displacement_squared = displacement * displacement;
+        const float projection = displacement * velocity_difference;
+        const float relative_scale =
+            sqrtf(displacement_squared *
+                  fmaxf(velocity_difference * velocity_difference, 1.0e-12f));
+        const float relative_limit = 1.0e-5f * relative_scale;
+        const float velocity_scale = fmaxf(sqrtf(velocity_i * velocity_i),
+                                           sqrtf(velocity_j * velocity_j));
+        const float roundoff_floor =
+            8.0f * FLT_EPSILON * sqrtf(displacement_squared) * velocity_scale;
+        const float tolerance = fmaxf(relative_limit, roundoff_floor);
+        if (!std::isfinite(projection) || !std::isfinite(tolerance) ||
+            std::fabs(projection) > tolerance)
+        {
+            std::fprintf(stderr,
+                         "%s residual %.9g exceeds attainable tolerance %.9g\n",
+                         name, static_cast<double>(std::fabs(projection)),
+                         static_cast<double>(tolerance));
+            return false;
+        }
+        exercised_roundoff_floor |= std::fabs(projection) > relative_limit &&
+                                    roundoff_floor > relative_limit;
+    }
+    return exercised_roundoff_floor ||
+           Fail("roundoff-floor case did not exercise the float bound");
+}
+
 bool Check_Settle()
 {
     CONSTRAIN constrain;
@@ -103,6 +161,16 @@ bool Check_Settle()
         return Fail("SETTLE velocity-only projection did not converge");
     if (!Check_Velocity_Only_Result("SETTLE", kCoordinates, coordinates,
                                     velocities))
+        return false;
+
+    std::memcpy(coordinates, kRoundoffCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kRoundoffVelocities, sizeof(velocities));
+    if (!settle.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kRoundoffMassInverse, direct_space,
+            direct_space, false))
+        return Fail("SETTLE rejected a float-limited attainable projection");
+    if (!Check_Roundoff_Floor_Result("SETTLE", kRoundoffCoordinates,
+                                     coordinates, velocities))
         return false;
 
     std::memcpy(coordinates, kCoordinates, sizeof(coordinates));
@@ -145,6 +213,16 @@ bool Check_Shake()
         return Fail("SHAKE velocity-only projection did not converge");
     if (!Check_Velocity_Only_Result("SHAKE", kCoordinates, coordinates,
                                     velocities))
+        return false;
+
+    std::memcpy(coordinates, kRoundoffCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kRoundoffVelocities, sizeof(velocities));
+    if (!shake.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kRoundoffMassInverse, direct_space,
+            direct_space, kAtomCount, false))
+        return Fail("SHAKE rejected a float-limited attainable projection");
+    if (!Check_Roundoff_Floor_Result("SHAKE", kRoundoffCoordinates, coordinates,
+                                     velocities))
         return false;
 
     std::memcpy(coordinates, kCoordinates, sizeof(coordinates));

--- a/benchmarks/validation/misc/tests/constraint_velocity_projection_probe.cpp
+++ b/benchmarks/validation/misc/tests/constraint_velocity_projection_probe.cpp
@@ -1,0 +1,219 @@
+﻿#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+#include "constrain/settle.h"
+#include "constrain/shake.h"
+
+unsigned int CONTROLLER::device_max_thread = 64;
+
+namespace
+{
+
+constexpr int kAtomCount = 3;
+constexpr int kPairCount = 3;
+
+const VECTOR kCoordinates[kAtomCount] = {
+    {0.0f, 0.0f, 0.0f},
+    {0.8233542f, -0.0292778f, 0.4872141f},
+    {-0.6461200f, -0.3741645f, 0.5988970f},
+};
+const VECTOR kVelocities[kAtomCount] = {
+    {0.3f, -0.2f, 0.4f},
+    {-0.7f, 0.5f, 0.1f},
+    {0.8f, 0.9f, -0.3f},
+};
+const float kMassInverse[kAtomCount] = {1.0f / 16.0f, 1.0f, 1.0f};
+const int kPairs[kPairCount][2] = {{0, 1}, {0, 2}, {1, 2}};
+
+bool Fail(const char* message)
+{
+    std::fprintf(stderr, "%s\n", message);
+    return false;
+}
+
+float Maximum_Relative_Residual(const VECTOR* coordinates,
+                                const VECTOR* velocities)
+{
+    float maximum = 0.0f;
+    for (const auto& pair : kPairs)
+    {
+        const VECTOR displacement = coordinates[pair[0]] - coordinates[pair[1]];
+        const VECTOR velocity_difference =
+            velocities[pair[0]] - velocities[pair[1]];
+        const float numerator = std::fabs(displacement * velocity_difference);
+        const float denominator =
+            std::sqrt((displacement * displacement) *
+                      (velocity_difference * velocity_difference));
+        maximum =
+            std::fmax(maximum, numerator / std::fmax(denominator, 1e-12f));
+    }
+    return maximum;
+}
+
+bool Check_Velocity_Only_Result(const char* name,
+                                const VECTOR* original_coordinates,
+                                const VECTOR* projected_coordinates,
+                                const VECTOR* projected_velocities)
+{
+    if (std::memcmp(original_coordinates, projected_coordinates,
+                    sizeof(kCoordinates)) != 0)
+        return Fail("velocity-only projection changed coordinates");
+    const float residual =
+        Maximum_Relative_Residual(projected_coordinates, projected_velocities);
+    if (!std::isfinite(residual) || residual > 2e-5f)
+    {
+        std::fprintf(stderr, "%s residual %.9g exceeds tolerance\n", name,
+                     static_cast<double>(residual));
+        return false;
+    }
+    return true;
+}
+
+bool Check_Settle()
+{
+    CONSTRAIN constrain;
+    constrain.dt = 0.002f;
+    // An unrelated high-degree SHAKE component must not reduce the SETTLE
+    // projection step or make an otherwise valid water fail to converge.
+    constrain.maximum_constraint_degree = 1024;
+
+    CONSTRAIN_TRIANGLE triangle = {};
+    triangle.atom_A = 0;
+    triangle.atom_B = 1;
+    triangle.atom_C = 2;
+    VECTOR delta_velocity[kAtomCount] = {};
+
+    SETTLE settle;
+    settle.is_initialized = 1;
+    settle.constrain = &constrain;
+    settle.local_atom_numbers = kAtomCount;
+    settle.num_triangle_local = 1;
+    settle.d_triangles_local = &triangle;
+    settle.d_delta_vel_local = delta_velocity;
+
+    VECTOR coordinates[kAtomCount];
+    VECTOR velocities[kAtomCount];
+    std::memcpy(coordinates, kCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kVelocities, sizeof(velocities));
+    const LTMatrix3 direct_space;
+    if (!settle.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kMassInverse, direct_space, direct_space,
+            false))
+        return Fail("SETTLE velocity-only projection did not converge");
+    if (!Check_Velocity_Only_Result("SETTLE", kCoordinates, coordinates,
+                                    velocities))
+        return false;
+
+    std::memcpy(coordinates, kCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kVelocities, sizeof(velocities));
+    if (!settle.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kMassInverse, direct_space, direct_space))
+        return Fail("SETTLE default projection reported failure");
+    return std::memcmp(kCoordinates, coordinates, sizeof(coordinates)) != 0 ||
+           Fail("SETTLE default projection no longer updates coordinates");
+}
+
+bool Check_Shake()
+{
+    CONSTRAIN constrain;
+    constrain.dt = 0.002f;
+    constrain.maximum_constraint_degree = 2;
+    CONSTRAIN_PAIR pairs[kPairCount] = {};
+    for (int index = 0; index < kPairCount; ++index)
+    {
+        pairs[index].atom_i_serial = kPairs[index][0];
+        pairs[index].atom_j_serial = kPairs[index][1];
+    }
+    constrain.num_pair_local = kPairCount;
+    constrain.constrain_pair_local = pairs;
+
+    VECTOR correction[kAtomCount] = {};
+    SHAKE shake;
+    shake.is_initialized = 1;
+    shake.constrain = &constrain;
+    shake.constrain_frc = correction;
+
+    VECTOR coordinates[kAtomCount];
+    VECTOR velocities[kAtomCount];
+    std::memcpy(coordinates, kCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kVelocities, sizeof(velocities));
+    const LTMatrix3 direct_space;
+    if (!shake.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kMassInverse, direct_space, direct_space,
+            kAtomCount, false))
+        return Fail("SHAKE velocity-only projection did not converge");
+    if (!Check_Velocity_Only_Result("SHAKE", kCoordinates, coordinates,
+                                    velocities))
+        return false;
+
+    std::memcpy(coordinates, kCoordinates, sizeof(coordinates));
+    std::memcpy(velocities, kVelocities, sizeof(velocities));
+    if (!shake.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, kMassInverse, direct_space, direct_space,
+            kAtomCount))
+        return Fail("SHAKE default projection reported failure");
+    return std::memcmp(kCoordinates, coordinates, sizeof(coordinates)) != 0 ||
+           Fail("SHAKE default projection no longer updates coordinates");
+}
+
+bool Check_Degenerate_Constraint_Status()
+{
+    CONSTRAIN constrain;
+    constrain.dt = 0.002f;
+    constrain.maximum_constraint_degree = 1;
+
+    CONSTRAIN_PAIR pair = {};
+    pair.atom_i_serial = 0;
+    pair.atom_j_serial = 1;
+    constrain.num_pair_local = 1;
+    constrain.constrain_pair_local = &pair;
+
+    VECTOR coordinates[2] = {};
+    VECTOR velocities[2] = {VECTOR(1.0f, 0.0f, 0.0f),
+                            VECTOR(-1.0f, 0.0f, 0.0f)};
+    const float dynamic_mass_inverse[2] = {1.0f, 1.0f};
+    const float fixed_mass_inverse[2] = {0.0f, 0.0f};
+    VECTOR correction[2] = {};
+    const LTMatrix3 direct_space;
+
+    SETTLE settle;
+    settle.is_initialized = 1;
+    settle.constrain = &constrain;
+    settle.local_atom_numbers = 2;
+    settle.num_pair_local = 1;
+    settle.d_pairs_local = &pair;
+    settle.d_delta_vel_local = correction;
+    if (settle.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, dynamic_mass_inverse, direct_space,
+            direct_space, false))
+        return Fail("SETTLE accepted a degenerate dynamic constraint");
+    if (!settle.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, fixed_mass_inverse, direct_space,
+            direct_space, false))
+        return Fail("SETTLE rejected an all-fixed constraint");
+
+    SHAKE shake;
+    shake.is_initialized = 1;
+    shake.constrain = &constrain;
+    shake.constrain_frc = correction;
+    if (shake.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, dynamic_mass_inverse, direct_space,
+            direct_space, 2, false))
+        return Fail("SHAKE accepted a degenerate dynamic constraint");
+    if (!shake.Project_Velocity_To_Constraint_Manifold(
+            velocities, coordinates, fixed_mass_inverse, direct_space,
+            direct_space, 2, false))
+        return Fail("SHAKE rejected an all-fixed constraint");
+    return true;
+}
+
+}  // namespace
+
+int main()
+{
+    return Check_Settle() && Check_Shake() &&
+                   Check_Degenerate_Constraint_Status()
+               ? 0
+               : 1;
+}

--- a/benchmarks/validation/misc/tests/settle_pair_guard_probe.cpp
+++ b/benchmarks/validation/misc/tests/settle_pair_guard_probe.cpp
@@ -1,0 +1,140 @@
+﻿#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+#include "constrain/settle.cpp"
+
+unsigned int CONTROLLER::device_max_thread = 64;
+
+namespace
+{
+
+bool Check_Pair(const char* name, const VECTOR& predicted,
+                const VECTOR& previous, const float target,
+                const bool should_fail)
+{
+    CONSTRAIN_PAIR pair = {};
+    pair.atom_i_serial = 0;
+    pair.atom_j_serial = 1;
+    pair.constant_r = target;
+    pair.constrain_k = 0.5f;
+    const int atom_local[2] = {10, 11};
+    const float mass[2] = {1.0f, 1.0f};
+    VECTOR coordinates[2] = {{0.0f, 0.0f, 0.0f}, predicted};
+    VECTOR velocities[2] = {{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}};
+    VECTOR last_pair[1] = {previous};
+    LTMatrix3 virial[1] = {{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}};
+    const VECTOR original_coordinates[2] = {coordinates[0], coordinates[1]};
+    const VECTOR original_velocities[2] = {velocities[0], velocities[1]};
+    const LTMatrix3 original_virial = virial[0];
+    const LTMatrix3 cell;
+    int invalid_pair = -1;
+
+    settle_pair(1, &pair, atom_local, mass, coordinates, cell, cell, last_pair,
+                0.002f, 1.0f, 1.0f, velocities, virial, &invalid_pair);
+
+    if (should_fail)
+    {
+        const bool unchanged =
+            std::memcmp(coordinates, original_coordinates,
+                        sizeof(coordinates)) == 0 &&
+            std::memcmp(velocities, original_velocities, sizeof(velocities)) ==
+                0 &&
+            std::memcmp(virial, &original_virial, sizeof(original_virial)) == 0;
+        if (invalid_pair == 0 && unchanged) return true;
+        std::fprintf(stderr, "%s did not fail before writing state\n", name);
+        return false;
+    }
+
+    const VECTOR constrained = coordinates[1] - coordinates[0];
+    const float distance = std::sqrt(constrained * constrained);
+    const bool finite_distance =
+        (Settle_Float_Bits(distance) & 0x7f800000U) != 0x7f800000U;
+    if (invalid_pair == -1 && finite_distance &&
+        std::fabs(distance - target) <= 2.0e-6f)
+        return true;
+    std::fprintf(stderr, "%s rejected a valid pair (distance %.9g)\n", name,
+                 static_cast<double>(distance));
+    return false;
+}
+
+bool Check_Float_Cancellation_Case()
+{
+    const VECTOR predicted = {1.50678098f, -2.55530214f, -1.57559633f};
+    const VECTOR previous = {-0.689187527f, 0.64532584f, 0.32950747f};
+    const float r1r1 = predicted * predicted;
+    const float r1r2 = predicted * previous;
+    const float r2r2 = previous * previous;
+    const float float_radicand = r1r2 * r1r2 - r1r1 * r2r2 + r2r2;
+    const double precise_radicand =
+        Settle_Pair_Precise_Radicand(predicted, previous, 1.0f, NULL);
+    if (!(float_radicand < 0.0f) ||
+        !Settle_Double_Is_Finite_Nonnegative(precise_radicand))
+    {
+        std::fprintf(
+            stderr,
+            "roundoff fixture no longer exercises float cancellation\n");
+        return false;
+    }
+    return Check_Pair("float-cancellation pair", predicted, previous, 1.0f,
+                      false);
+}
+
+bool Check_Float_False_Positive_Case()
+{
+    const VECTOR predicted = {0.769227564f, 0.589192092f, 1.73570371f};
+    const VECTOR previous = {0.359873652f, 0.728374541f, 0.583062232f};
+    const float r1r1 = predicted * predicted;
+    const float r1r2 = predicted * previous;
+    const float r2r2 = previous * previous;
+    const float float_radicand = r1r2 * r1r2 - r1r1 * r2r2 + r2r2;
+    const double precise_radicand =
+        Settle_Pair_Precise_Radicand(predicted, previous, 1.0f, NULL);
+    if (!(float_radicand > 0.0f) ||
+        Settle_Double_Is_Finite_Nonnegative(precise_radicand))
+    {
+        std::fprintf(stderr,
+                     "roundoff fixture no longer exercises a float false "
+                     "positive\n");
+        return false;
+    }
+    return Check_Pair("float-false-positive pair", predicted, previous, 1.0f,
+                      true);
+}
+
+bool Check_Precise_K_Overflow()
+{
+    const VECTOR predicted = {0.0f, 0.0f, 0.0f};
+    const VECTOR previous = {FLT_MIN, 0.0f, 0.0f};
+    float k = 123.0f;
+    return !Settle_Try_Precise_Pair_Solution(predicted, previous, FLT_MAX,
+                                             &k) &&
+           k == 123.0f;
+}
+
+}  // namespace
+
+int main()
+{
+    const VECTOR old_x = {1.0f, 0.0f, 0.0f};
+    const VECTOR ordinary = {1.2f, 0.2f, 0.0f};
+    const VECTOR just_inside = {0.0f, std::nextafter(1.0f, 0.0f), 0.0f};
+    const VECTOR tangent = {0.0f, 1.0f, 0.0f};
+    const VECTOR just_outside = {0.0f, std::nextafter(1.0f, 2.0f), 0.0f};
+    const VECTOR observed = {-0.511489868f, 1.50683594f, 0.117248535f};
+    const VECTOR observed_previous = {0.13999939f, 0.509994507f, 0.939994812f};
+
+    return Check_Pair("ordinary pair", ordinary, old_x, 1.0f, false) &&
+                   Check_Pair("inside-boundary pair", just_inside, old_x, 1.0f,
+                              false) &&
+                   Check_Pair("tangent pair", tangent, old_x, 1.0f, false) &&
+                   Check_Float_Cancellation_Case() &&
+                   Check_Float_False_Positive_Case() &&
+                   Check_Precise_K_Overflow() &&
+                   Check_Pair("outside-boundary pair", just_outside, old_x,
+                              1.0f, true) &&
+                   Check_Pair("observed negative-radicand pair", observed,
+                              observed_previous, 1.08000004f, true)
+               ? 0
+               : 1;
+}

--- a/benchmarks/validation/misc/tests/test_constraint_velocity_projection.py
+++ b/benchmarks/validation/misc/tests/test_constraint_velocity_projection.py
@@ -1,0 +1,93 @@
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+PROBE_SOURCE = Path(__file__).with_name(
+    "constraint_velocity_projection_probe.cpp"
+)
+
+
+def _compiler_command():
+    configured = os.environ.get("CXX")
+    if configured:
+        return shlex.split(configured)
+    if sys.platform == "darwin" and Path("/usr/bin/clang++").is_file():
+        return ["/usr/bin/clang++"]
+    compiler = (
+        shutil.which("c++") or shutil.which("clang++") or shutil.which("g++")
+    )
+    if compiler is None:
+        pytest.skip("a C++17 compiler is required for the constraint probe")
+    return [compiler]
+
+
+def _dependency_include():
+    candidates = []
+    if os.environ.get("CONDA_PREFIX"):
+        candidates.append(Path(os.environ["CONDA_PREFIX"]) / "include")
+    candidates.append(
+        REPOSITORY_ROOT / ".pixi" / "envs" / "dev-cpu" / "include"
+    )
+    for candidate in candidates:
+        if (candidate / "omp.h").is_file() and (
+            candidate / "fftw3.h"
+        ).is_file():
+            return candidate
+    pytest.skip("OpenMP and FFTW headers are required for the constraint probe")
+
+
+def test_velocity_only_constraint_projection_converges_without_moving_crd(
+    tmp_path,
+):
+    executable = tmp_path / "constraint_velocity_projection_probe"
+    dead_code_flags = (
+        ["-Wl,-dead_strip"]
+        if sys.platform == "darwin"
+        else ["-Wl,--gc-sections"]
+    )
+    compile_result = subprocess.run(
+        [
+            *_compiler_command(),
+            "-std=c++17",
+            "-DUSE_CPU",
+            "-DNO_GLOBAL_CONTROLLER",
+            "-O3",
+            "-march=native",
+            "-ffast-math",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-w",
+            f"-I{REPOSITORY_ROOT / 'SPONGE'}",
+            f"-I{_dependency_include()}",
+            str(PROBE_SOURCE),
+            str(REPOSITORY_ROOT / "SPONGE/constrain/settle.cpp"),
+            str(REPOSITORY_ROOT / "SPONGE/constrain/shake.cpp"),
+            str(REPOSITORY_ROOT / "SPONGE/common.cpp"),
+            *dead_code_flags,
+            "-o",
+            str(executable),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+    assert compile_result.returncode == 0, (
+        "failed to compile constraint projection probe\n"
+        f"stdout:\n{compile_result.stdout}\nstderr:\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run(
+        [str(executable)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr

--- a/benchmarks/validation/misc/tests/test_settle_pair_guard.py
+++ b/benchmarks/validation/misc/tests/test_settle_pair_guard.py
@@ -1,0 +1,89 @@
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+PROBE_SOURCE = Path(__file__).with_name("settle_pair_guard_probe.cpp")
+
+
+def _compiler_command():
+    configured = os.environ.get("CXX")
+    if configured:
+        return shlex.split(configured)
+    if sys.platform == "darwin" and Path("/usr/bin/clang++").is_file():
+        return ["/usr/bin/clang++"]
+    compiler = (
+        shutil.which("c++") or shutil.which("clang++") or shutil.which("g++")
+    )
+    if compiler is None:
+        pytest.skip("a C++17 compiler is required for the SETTLE pair probe")
+    return [compiler]
+
+
+def _dependency_include():
+    candidates = []
+    if os.environ.get("CONDA_PREFIX"):
+        candidates.append(Path(os.environ["CONDA_PREFIX"]) / "include")
+    candidates.append(
+        REPOSITORY_ROOT / ".pixi" / "envs" / "dev-cpu" / "include"
+    )
+    for candidate in candidates:
+        if (candidate / "omp.h").is_file() and (
+            candidate / "fftw3.h"
+        ).is_file():
+            return candidate
+    pytest.skip(
+        "OpenMP and FFTW headers are required for the SETTLE pair probe"
+    )
+
+
+def test_settle_pair_rejects_invalid_update_before_writing_state(tmp_path):
+    executable = tmp_path / "settle_pair_guard_probe"
+    dead_code_flags = (
+        ["-Wl,-dead_strip"]
+        if sys.platform == "darwin"
+        else ["-Wl,--gc-sections"]
+    )
+    compile_result = subprocess.run(
+        [
+            *_compiler_command(),
+            "-std=c++17",
+            "-DUSE_CPU",
+            "-DNO_GLOBAL_CONTROLLER",
+            "-O3",
+            "-march=native",
+            "-ffast-math",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-w",
+            f"-I{REPOSITORY_ROOT / 'SPONGE'}",
+            f"-I{_dependency_include()}",
+            str(PROBE_SOURCE),
+            str(REPOSITORY_ROOT / "SPONGE/common.cpp"),
+            *dead_code_flags,
+            "-o",
+            str(executable),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+    assert compile_result.returncode == 0, (
+        "failed to compile SETTLE pair guard probe\n"
+        f"stdout:\n{compile_result.stdout}\nstderr:\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run(
+        [str(executable)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr


### PR DESCRIPTION
## 合并目的与顺序

将 `lab/pku` 中已合并的约束算法修复、GROMACS 拓扑导入修复、初始化性能优化和 macOS PRIPS CI 修复同步到 `master`。包含源 PR #48、#49、#50、#52。

本 PR 是本轮回合的第二个 PR，计划在 #55（`lab/sidereus-ai → master`）之后合并。建议使用 **Create a merge commit** 保留长期 lab 分支的提交关系。#55 合入后，应重新核对本 PR 相对最新 `master` 的差异和集成检查。

## 功能与正确性修复

### SETTLE pair 更新保护（#48）

- 在写回坐标、速度等状态之前检查 pair 更新的可解性，拒绝明显为负的根号项以及 NaN/Inf，避免无效数值污染后续模拟。
- 对舍入误差范围内的边界情况使用 double 精度重算；真正不可解的更新按 CPU/GPU 错误路径明确中止。
- 有限性判断使用位级检测，避免 fast-math 优化移除检查。
- 新增 `settle_pair_guard_probe.cpp` 和对应 Python 测试，覆盖启用 `-ffast-math` 时仍应在写状态前拒绝无效更新的行为。

### 仅速度约束投影与浮点收敛判据（#49）

- 支持不移动坐标的 velocity-only 约束投影，用于只需修正速度的路径。
- 采用与约束连接度相关的阻尼迭代；velocity-only 路径最多迭代 512 次，保留原坐标更新路径的迭代行为。
- 收敛判据同时考虑相对容差和 float 舍入下限，避免残差已经达到浮点精度极限时仍被误判为不收敛。
- 新增共享容差计算头文件，以及验证速度约束收敛、坐标保持不变的 probe 和 Python 回归测试。

### GROMACS 拓扑语义与错误定位（#50）

- 解析并归一化显式 `[ exclusions ]`，去重并正确处理排除关系。
- 显式 exclusions 优先于同一原子对的 `[ pairs ]`，不再继续生成该对的 1-4 LJ/Coulomb 项；保留普通 nrexcl 推导排除与 1-4 pair 的区别，并报告被覆盖的 pair 数量。
- 对不支持的 section 报出文件及行号，避免静默忽略导致模拟语义变化；明确允许 `[ system ]` 元数据。
- 新增 direct top/gro section-integrity 回归测试，覆盖 include 源位置、非活动预处理分支、排除关系和显式 exclusions 对 1-4 项的覆盖。

## 初始化性能优化（#52）

- 分子周期性检查复用原子映射缓冲区，避免在逐分子循环中重复分配、清零；连接图和分子列表通过引用传递，减少深拷贝。
- update-group setup 利用连续的原子索引宿主内存集中上传，减少大量小规模复制。
- GPU 邻居网格初始化直接枚举周期镜像候选网格并排序去重；候选容量不足时保留原扫描回退，CPU 构建继续使用扫描路径。
- LJ 长程 C6 系数改为按类型直方图在宿主端以固定顺序 double 累加，减少原子级双重求和，并消除原 float atomicAdd 累加的运行间抖动。

源 PR #52 报告的性能数据如下，测试环境为 Spike 55.6 万原子体系、RTX 5090、warm cache。这些是源 PR 的历史测量，不是本次 master 集成重新测得，也不代表所有体系或平台的保证值。

| 指标 | 优化前 | 优化后 |
| --- | ---: | ---: |
| 分子周期性检查 | 41.1 s | 0.12 s |
| 邻居网格初始化 kernel | 1.55 s | 约 1 ms |
| C6 初始化计算 | 0.86 s | 约 0.01 s |
| 初始化总耗时 | 50.9 s | 5.3 s |

## CI 调整

- 三个 PR workflow 的目标分支规则支持 `master` 和 `lab/**`。其中 `lab/**` 规则也在 #55 中；共同变更按文件内容合并即可。
- 仅在 macOS ARM64 PRIPS 后端测试中固定 `torch==2.13.0`，避开 PyTorch 2.14.0 macOS wheel 的重复 OpenMP 加载故障。
- Linux/Windows 的 PyTorch 安装策略保持原样；未给 SPONGE 或 PRIPS 增加 PyTorch 必需依赖，也未通过设置 `KMP_DUPLICATE_LIB_OK=TRUE` 来绕过 macOS 冲突。

## 验证记录及本次验收

- 约束和 GROMACS 变更随代码携带上述回归测试；本 PR 的 CI 负责在集成分支上重新验证。
- #52 的提交说明记录了大体系能量对比及邻居网格与原扫描实现的一致性检查。原提交也说明完整 validation 在当时环境中存在与基线相同的失败集，不能将源分支验证描述为所有测试均通过。
- macOS pin 补丁 `26fea32` 已通过[专项验证](https://github.com/SPONGEMM/SPONGE/actions/runs/33843360172/job/100929995542)：任务固定检出该提交，NumPy、JAX、PyTorch 三个 PRIPS 测试步骤全部成功。该记录不等同于本次 master 集成的全量 CI。
- 本 PR 的检查结果以新产生的 CI 为准；在 #55 合入后，还需核对本 PR 基于更新后 master 的合并状态及必要的集成验证。

## 审查与合并注意事项

- 重点检查约束错误退出、float 收敛边界、显式 exclusions 对能量项的影响，以及 GPU 网格回退和邻居容量边界。
- C6 累加顺序与精度发生变化，应按相应数值容差比较结果，不要求与原 float atomicAdd 输出逐位相同。
- #55 尚未包含 macOS PyTorch pin；若第一步的合并门禁要求全绿，应先单独同步 CI 修复或协调合并顺序，不应将失败检查视为已通过。
- 完成两个回合 PR 后，将最新 master 同步回长期 lab 分支。
