### PR TITLE
Add constrained Maxwell initial velocities from lab/pku

### DIFF
--- a/SPONGE/MD_core/initial_velocity.cpp
+++ b/SPONGE/MD_core/initial_velocity.cpp
@@ -1,0 +1,410 @@
+﻿#include "initial_velocity.h"
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <random>
+#include <vector>
+
+#include "../Domain_decomposition/Domain_decomposition.h"
+#include "../constrain/settle.h"
+#include "../constrain/shake.h"
+#include "MD_core.h"
+
+namespace
+{
+constexpr const char* kModuleName = "initial_velocity";
+constexpr const char* kErrorBy = "INITIAL_VELOCITY_INFORMATION::Initial";
+constexpr const char* kFinalizeErrorBy =
+    "INITIAL_VELOCITY_INFORMATION::Finalize";
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((noinline))
+#endif
+bool Float_Bits_Are_Finite(const void* address)
+{
+    std::uint32_t bits = 0;
+    static_assert(sizeof(bits) == sizeof(float), "unexpected float size");
+    std::memcpy(&bits, address, sizeof(bits));
+    return (bits & UINT32_C(0x7f800000)) != UINT32_C(0x7f800000);
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((noinline))
+#endif
+bool Double_Bits_Are_Finite(const void* address)
+{
+    std::uint64_t bits = 0;
+    static_assert(sizeof(bits) == sizeof(double), "unexpected double size");
+    std::memcpy(&bits, address, sizeof(bits));
+    return (bits & UINT64_C(0x7ff0000000000000)) !=
+           UINT64_C(0x7ff0000000000000);
+}
+
+void Throw_Input_Error(CONTROLLER* controller, const char* reason)
+{
+    controller->Throw_Formatted_SPONGE_Error(
+        spongeErrorValueErrorCommand, kErrorBy,
+        "Reason:\n\tinvalid [initial_velocity] configuration: %s\n", reason);
+}
+
+bool Parse_Seed(const char* token, std::uint64_t* value)
+{
+    if (token == nullptr || token[0] == '\0' || value == nullptr) return false;
+    const std::uint64_t maximum =
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+    std::uint64_t parsed = 0;
+    for (const char* cursor = token; *cursor != '\0'; ++cursor)
+    {
+        if (*cursor < '0' || *cursor > '9') return false;
+        const std::uint64_t digit = static_cast<std::uint64_t>(*cursor - '0');
+        if (parsed > (maximum - digit) / 10) return false;
+        parsed = parsed * 10 + digit;
+    }
+    *value = parsed;
+    return true;
+}
+
+void Generate_Maxwell_Direction(CONTROLLER* controller, MD_INFORMATION* md_info,
+                                std::uint64_t seed)
+{
+    std::mt19937_64 generator(seed);
+    std::normal_distribution<double> normal(0.0, 1.0);
+    const double thermal_energy =
+        static_cast<double>(CONSTANT_kB) *
+        static_cast<double>(md_info->sys.target_temperature);
+    double total_mass = 0.0;
+    double momentum_x = 0.0;
+    double momentum_y = 0.0;
+    double momentum_z = 0.0;
+
+    for (int atom = 0; atom < md_info->atom_numbers; ++atom)
+    {
+        const double mass = static_cast<double>(md_info->h_mass[atom]);
+        if (!Float_Bits_Are_Finite(&md_info->h_mass[atom]) || mass < 0.0)
+        {
+            controller->Throw_Formatted_SPONGE_Error(
+                spongeErrorValueErrorCommand, kErrorBy,
+                "Reason:\n\tatom %d has non-finite or negative mass %.9g "
+                "during Maxwell initialization\n",
+                atom, mass);
+        }
+        if (mass == 0.0)
+        {
+            md_info->velocity[atom] = {0.0f, 0.0f, 0.0f};
+            continue;
+        }
+        const double sigma = std::sqrt(thermal_energy / mass);
+        VECTOR velocity = {static_cast<float>(sigma * normal(generator)),
+                           static_cast<float>(sigma * normal(generator)),
+                           static_cast<float>(sigma * normal(generator))};
+        if (!Float_Bits_Are_Finite(&velocity.x) ||
+            !Float_Bits_Are_Finite(&velocity.y) ||
+            !Float_Bits_Are_Finite(&velocity.z))
+        {
+            controller->Throw_SPONGE_Error(
+                spongeErrorSimulationBreakDown, kErrorBy,
+                "Reason:\n\tthe generated initial velocity is outside the "
+                "finite single-precision range\n");
+        }
+        md_info->velocity[atom] = velocity;
+        total_mass += mass;
+        momentum_x += mass * static_cast<double>(velocity.x);
+        momentum_y += mass * static_cast<double>(velocity.y);
+        momentum_z += mass * static_cast<double>(velocity.z);
+    }
+
+    if (!Double_Bits_Are_Finite(&total_mass) || !(total_mass > 0.0))
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorValueErrorCommand, kErrorBy,
+            "Reason:\n\tMaxwell initialization requires at least one atom "
+            "with positive finite mass\n");
+    }
+    const double center_velocity_x = momentum_x / total_mass;
+    const double center_velocity_y = momentum_y / total_mass;
+    const double center_velocity_z = momentum_z / total_mass;
+    for (int atom = 0; atom < md_info->atom_numbers; ++atom)
+    {
+        if (md_info->h_mass[atom] == 0.0f) continue;
+        VECTOR& velocity = md_info->velocity[atom];
+        velocity.x = static_cast<float>(static_cast<double>(velocity.x) -
+                                        center_velocity_x);
+        velocity.y = static_cast<float>(static_cast<double>(velocity.y) -
+                                        center_velocity_y);
+        velocity.z = static_cast<float>(static_cast<double>(velocity.z) -
+                                        center_velocity_z);
+        if (!Float_Bits_Are_Finite(&velocity.x) ||
+            !Float_Bits_Are_Finite(&velocity.y) ||
+            !Float_Bits_Are_Finite(&velocity.z))
+        {
+            controller->Throw_SPONGE_Error(
+                spongeErrorSimulationBreakDown, kErrorBy,
+                "Reason:\n\tCOM removal produced a non-finite initial "
+                "velocity\n");
+        }
+    }
+}
+
+double Local_Kinetic_Energy(CONTROLLER* controller,
+                            const DOMAIN_INFORMATION* dd)
+{
+    std::vector<VECTOR> velocity(static_cast<std::size_t>(dd->atom_numbers));
+    std::vector<float> mass(static_cast<std::size_t>(dd->atom_numbers));
+    if (dd->atom_numbers > 0)
+    {
+        deviceMemcpy(
+            velocity.data(), dd->vel,
+            sizeof(VECTOR) * static_cast<std::size_t>(dd->atom_numbers),
+            deviceMemcpyDeviceToHost);
+        deviceMemcpy(mass.data(), dd->d_mass,
+                     sizeof(float) * static_cast<std::size_t>(dd->atom_numbers),
+                     deviceMemcpyDeviceToHost);
+    }
+
+    double kinetic_energy = 0.0;
+    for (int atom = 0; atom < dd->atom_numbers; ++atom)
+    {
+        const VECTOR& v = velocity[atom];
+        const double atom_mass = static_cast<double>(mass[atom]);
+        const double velocity_squared =
+            static_cast<double>(v.x) * static_cast<double>(v.x) +
+            static_cast<double>(v.y) * static_cast<double>(v.y) +
+            static_cast<double>(v.z) * static_cast<double>(v.z);
+        const double contribution = 0.5 * atom_mass * velocity_squared;
+        if (!Double_Bits_Are_Finite(&contribution) || contribution < 0.0)
+        {
+            controller->Throw_SPONGE_Error(
+                spongeErrorSimulationBreakDown, kFinalizeErrorBy,
+                "Reason:\n\tthe projected initial velocity has non-finite "
+                "or negative kinetic energy\n");
+        }
+        kinetic_energy += contribution;
+    }
+    if (!Double_Bits_Are_Finite(&kinetic_energy) || kinetic_energy < 0.0)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kFinalizeErrorBy,
+            "Reason:\n\tthe local initial kinetic-energy sum is non-finite "
+            "or negative\n");
+    }
+    return kinetic_energy;
+}
+
+double Global_Kinetic_Energy(CONTROLLER* controller,
+                             const DOMAIN_INFORMATION* dd)
+{
+    const double local = Local_Kinetic_Energy(controller, dd);
+    double global = local;
+#ifdef USE_MPI
+    const int status = MPI_Allreduce(&local, &global, 1, MPI_DOUBLE, MPI_SUM,
+                                     CONTROLLER::pp_comm);
+    if (status != MPI_SUCCESS)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kFinalizeErrorBy,
+            "Reason:\n\tthe PP kinetic-energy reduction failed\n");
+    }
+#endif
+    return global;
+}
+}  // namespace
+
+void INITIAL_VELOCITY_INFORMATION::Initial(CONTROLLER* controller,
+                                           MD_INFORMATION* md_info)
+{
+    const bool has_mode = controller->Command_Exist(kModuleName, "mode");
+    const bool has_seed = controller->Command_Exist(kModuleName, "seed");
+    if (!has_mode && !has_seed) return;
+    if (!has_mode)
+    {
+        Throw_Input_Error(controller, "'mode' is required");
+    }
+    if (!has_seed)
+    {
+        Throw_Input_Error(controller, "'seed' is required for mode=maxwell");
+    }
+    if (!controller->Command_Choice(kModuleName, "mode", "maxwell"))
+    {
+        Throw_Input_Error(controller, "'mode' must be \"maxwell\"");
+    }
+    if (!Parse_Seed(controller->Command(kModuleName, "seed"), &seed))
+    {
+        Throw_Input_Error(controller,
+                          "'seed' must be an integer in [0, INT64_MAX]");
+    }
+    if (md_info->mode == md_info->MINIMIZATION ||
+        md_info->mode == md_info->RERUN)
+    {
+        Throw_Input_Error(
+            controller,
+            "mode=maxwell is not defined for minimization or rerun mode");
+    }
+    if (md_info->atom_numbers <= 0 || md_info->velocity == nullptr ||
+        md_info->vel == nullptr || md_info->h_mass == nullptr)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kErrorBy,
+            "Reason:\n\tthe atom velocity or mass storage is unavailable\n");
+    }
+    if (md_info->sys.freedom <= 0)
+    {
+        controller->Throw_Formatted_SPONGE_Error(
+            spongeErrorValueErrorCommand, kErrorBy,
+            "Reason:\n\tMaxwell initialization requires positive final "
+            "degrees of freedom; got %d\n",
+            md_info->sys.freedom);
+    }
+    if (!Float_Bits_Are_Finite(&md_info->sys.target_temperature) ||
+        !(md_info->sys.target_temperature > 0.0f))
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorValueErrorCommand, kErrorBy,
+            "Reason:\n\tMaxwell initialization requires a finite positive "
+            "step-zero target temperature\n");
+    }
+
+    if (CONTROLLER::MPI_rank == SPONGE_MPI_ROOT)
+    {
+        Generate_Maxwell_Direction(controller, md_info, seed);
+    }
+#ifdef USE_MPI
+    const std::size_t byte_count =
+        sizeof(VECTOR) * static_cast<std::size_t>(md_info->atom_numbers);
+    if (byte_count > static_cast<std::size_t>(std::numeric_limits<int>::max()))
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kErrorBy,
+            "Reason:\n\tthe initial velocity field is too large for one MPI "
+            "broadcast\n");
+    }
+    const int status =
+        MPI_Bcast(md_info->velocity, static_cast<int>(byte_count), MPI_BYTE,
+                  SPONGE_MPI_ROOT, MPI_COMM_WORLD);
+    if (status != MPI_SUCCESS)
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kErrorBy,
+            "Reason:\n\tthe initial velocity broadcast failed\n");
+    }
+#endif
+    deviceMemcpy(
+        md_info->vel, md_info->velocity,
+        sizeof(VECTOR) * static_cast<std::size_t>(md_info->atom_numbers),
+        deviceMemcpyHostToDevice);
+    is_initialized = true;
+    controller->printf(
+        "INITIAL VELOCITY: mode=maxwell, seed %llu, target %.9g K, final "
+        "freedom %d\n",
+        static_cast<unsigned long long>(seed),
+        static_cast<double>(md_info->sys.target_temperature),
+        md_info->sys.freedom);
+}
+
+void INITIAL_VELOCITY_INFORMATION::Finalize(CONTROLLER* controller,
+                                            MD_INFORMATION* md_info,
+                                            DOMAIN_INFORMATION* dd,
+                                            SETTLE* settle, SHAKE* shake)
+{
+    if (!is_initialized || is_finalized) return;
+    if (CONTROLLER::MPI_rank >= CONTROLLER::PP_MPI_size)
+    {
+        is_finalized = true;
+        return;
+    }
+
+    if (!settle->Project_Velocity_To_Constraint_Manifold(
+            dd->vel, dd->crd, dd->d_mass_inverse, md_info->pbc.cell,
+            md_info->pbc.rcell, false))
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kFinalizeErrorBy,
+            "Reason:\n\tthe initial SETTLE velocity projection did not "
+            "converge\n");
+    }
+    if (!shake->Project_Velocity_To_Constraint_Manifold(
+            dd->vel, dd->crd, dd->d_mass_inverse, md_info->pbc.cell,
+            md_info->pbc.rcell, dd->atom_numbers, false))
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kFinalizeErrorBy,
+            "Reason:\n\tthe initial SHAKE velocity projection did not "
+            "converge\n");
+    }
+
+    const double kinetic_energy = Global_Kinetic_Energy(controller, dd);
+    if (!Double_Bits_Are_Finite(&kinetic_energy) || !(kinetic_energy > 0.0))
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kFinalizeErrorBy,
+            "Reason:\n\tconstraint projection left no finite positive "
+            "kinetic energy to rescale\n");
+    }
+    const double projected_temperature =
+        2.0 * kinetic_energy /
+        (static_cast<double>(md_info->sys.freedom) *
+         static_cast<double>(CONSTANT_kB));
+    if (!Double_Bits_Are_Finite(&projected_temperature) ||
+        !(projected_temperature > 0.0))
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kFinalizeErrorBy,
+            "Reason:\n\tthe projected initial temperature is not finite and "
+            "positive\n");
+    }
+    const double target_kinetic_energy =
+        0.5 * static_cast<double>(md_info->sys.freedom) *
+        static_cast<double>(CONSTANT_kB) *
+        static_cast<double>(md_info->sys.target_temperature);
+    const double scale_double =
+        std::sqrt(target_kinetic_energy / kinetic_energy);
+    const float scale = static_cast<float>(scale_double);
+    if (!Double_Bits_Are_Finite(&target_kinetic_energy) ||
+        !(target_kinetic_energy > 0.0) ||
+        !Double_Bits_Are_Finite(&scale_double) || !(scale_double > 0.0) ||
+        !Float_Bits_Are_Finite(&scale) || !(scale > 0.0f))
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kFinalizeErrorBy,
+            "Reason:\n\tthe target initial kinetic energy cannot be "
+            "represented by a finite velocity scale\n");
+    }
+    Scale_List(reinterpret_cast<float*>(dd->vel), scale, 3 * dd->atom_numbers);
+
+    const double final_kinetic_energy = Global_Kinetic_Energy(controller, dd);
+    const double final_temperature =
+        2.0 * final_kinetic_energy /
+        (static_cast<double>(md_info->sys.freedom) *
+         static_cast<double>(CONSTANT_kB));
+    const float stored_temperature = static_cast<float>(final_temperature);
+    if (!Double_Bits_Are_Finite(&final_temperature) ||
+        !Float_Bits_Are_Finite(&stored_temperature) ||
+        !(stored_temperature > 0.0f))
+    {
+        controller->Throw_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kFinalizeErrorBy,
+            "Reason:\n\tthe finalized initial temperature is not finite and "
+            "positive\n");
+    }
+    const double relative_temperature_error =
+        std::abs(final_temperature -
+                 static_cast<double>(md_info->sys.target_temperature)) /
+        static_cast<double>(md_info->sys.target_temperature);
+    if (!Double_Bits_Are_Finite(&relative_temperature_error) ||
+        relative_temperature_error > 1.0e-5)
+    {
+        controller->Throw_Formatted_SPONGE_Error(
+            spongeErrorSimulationBreakDown, kFinalizeErrorBy,
+            "Reason:\n\tfinal initial temperature %.9g K differs from target "
+            "%.9g K after float velocity scaling\n",
+            final_temperature,
+            static_cast<double>(md_info->sys.target_temperature));
+    }
+    dd->h_ek_total = static_cast<float>(final_kinetic_energy);
+    dd->temperature = stored_temperature;
+    md_info->sys.h_temperature = stored_temperature;
+    is_finalized = true;
+    controller->printf("INITIAL VELOCITY: projected %.9g K, final %.9g K\n",
+                       projected_temperature,
+                       static_cast<double>(stored_temperature));
+}

--- a/SPONGE/MD_core/initial_velocity.h
+++ b/SPONGE/MD_core/initial_velocity.h
@@ -1,0 +1,23 @@
+﻿#pragma once
+
+#include <cstdint>
+
+struct CONTROLLER;
+struct DOMAIN_INFORMATION;
+struct MD_INFORMATION;
+struct SETTLE;
+struct SHAKE;
+
+// Optional generation of a new initial velocity field.  Initial() runs after
+// the step-zero target schedule and final freedom calculation; Finalize() runs
+// after domain decomposition has built the local constraint maps.
+struct INITIAL_VELOCITY_INFORMATION
+{
+    bool is_initialized = false;
+    bool is_finalized = false;
+    std::uint64_t seed = 0;
+
+    void Initial(CONTROLLER* controller, MD_INFORMATION* md_info);
+    void Finalize(CONTROLLER* controller, MD_INFORMATION* md_info,
+                  DOMAIN_INFORMATION* dd, SETTLE* settle, SHAKE* shake);
+};

--- a/SPONGE/MD_core/sys.hpp
+++ b/SPONGE/MD_core/sys.hpp
@@ -561,8 +561,7 @@ void MD_INFORMATION::system_information::Initial(CONTROLLER* controller,
         }
 
         target_temperature = 300.0f;
-        if (md_info->mode >= md_info->NVT &&
-            controller[0].Command_Exist("target_temperature"))
+        if (controller[0].Command_Exist("target_temperature"))
         {
             controller->Check_Float(
                 "target_temperature",

--- a/SPONGE/main.cpp
+++ b/SPONGE/main.cpp
@@ -19,6 +19,7 @@
 CONTROLLER controller;
 Xponge::System Xponge::system;
 MD_INFORMATION md_info;
+INITIAL_VELOCITY_INFORMATION initial_velocity;
 DOMAIN_INFORMATION dd;
 MIDDLE_Langevin_INFORMATION middle_langevin;
 ANDERSEN_THERMOSTAT_INFORMATION ad_thermo;
@@ -1096,6 +1097,7 @@ void Main_Initial(int argc, char* argv[])
     cv_controller.Initial(&controller,
                           &md_info.no_direct_interaction_virtual_atom_numbers);
     md_info.Initial(&controller);
+    md_info.sys.Update_Targets_By_Schedule(0);
     controller.Step_Print_Initial("potential", "%.2f");
     controller.Step_Print_Initial("eff_pot", "%.7e");
     qc.Initial(&controller, md_info.atom_numbers, md_info.crd);
@@ -1251,6 +1253,7 @@ void Main_Initial(int argc, char* argv[])
                   cv_controller.cv_vatom_name, md_info.h_mass,
                   &md_info.sys.freedom, &md_info.sys.connectivity);
     vatom.Coordinate_Refresh(md_info.crd, md_info.pbc.cell, md_info.pbc.rcell);
+    initial_velocity.Initial(&controller, &md_info);
 
     if (md_info.pbc.pbc)
     {
@@ -1284,6 +1287,7 @@ void Main_Initial(int argc, char* argv[])
     if (CONTROLLER::MPI_rank < CONTROLLER::PP_MPI_size)
     {
         Main_Refresh_Local_State(true);
+        initial_velocity.Finalize(&controller, &md_info, &dd, &settle, &shake);
         plugin.Set_Domain_Information(&dd);
     }
 

--- a/SPONGE/main.h
+++ b/SPONGE/main.h
@@ -6,6 +6,7 @@
 #include "Lennard_Jones_force/Lennard_Jones_force.h"
 #include "Lennard_Jones_force/solvent_LJ.h"
 #include "MD_core/MD_core.h"
+#include "MD_core/initial_velocity.h"
 #include "NO_PBC/Coulomb_Force_No_PBC.h"
 #include "NO_PBC/Lennard_Jones_force_No_PBC.h"
 #include "NO_PBC/generalized_Born.h"

--- a/benchmarks/validation/misc/tests/test_initial_velocity.py
+++ b/benchmarks/validation/misc/tests/test_initial_velocity.py
@@ -1,0 +1,505 @@
+import json
+import math
+import os
+import re
+import shutil
+import struct
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+KB_KCAL_PER_MOL_K = 0.00198716
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _write_native_case(
+    case_dir,
+    *,
+    masses=(12.0, 16.0, 1.0, 0.0),
+    velocities=None,
+    mode="nve",
+    seed=202607220001,
+    enable_initial_velocity=True,
+    target_temperature=300.0,
+    settings_overrides=None,
+    extra_root_lines=(),
+):
+    case_dir.mkdir(parents=True)
+    atom_count = len(masses)
+    coordinates = [
+        (1.0 + 2.0 * atom, 2.0 + 0.5 * atom, 3.0 + 0.25 * atom)
+        for atom in range(atom_count)
+    ]
+    (case_dir / "mass.txt").write_text(
+        f"{atom_count}\n" + "\n".join(str(mass) for mass in masses) + "\n",
+        encoding="utf-8",
+    )
+    (case_dir / "charge.txt").write_text(
+        f"{atom_count}\n" + "0\n" * atom_count,
+        encoding="utf-8",
+    )
+    coordinate_lines = [str(atom_count)]
+    coordinate_lines.extend(
+        " ".join(str(component) for component in coordinate)
+        for coordinate in coordinates
+    )
+    coordinate_lines.extend(("1000 1000 1000", "90 90 90"))
+    (case_dir / "coordinate.txt").write_text(
+        "\n".join(coordinate_lines) + "\n", encoding="utf-8"
+    )
+
+    settings = {
+        "md_name": case_dir.name,
+        "mode": mode,
+        "pbc": False,
+        "step_limit": 1,
+        "dt": 0,
+        "cutoff": 8.0,
+        "PM.MPI_size": 0,
+        "target_temperature": target_temperature,
+        "mass_in_file": "mass.txt",
+        "charge_in_file": "charge.txt",
+        "coordinate_in_file": "coordinate.txt",
+        "print_zeroth_frame": True,
+        "write_mdout_interval": 1,
+        "write_information_interval": 1,
+        "write_trajectory_interval": 1,
+        "write_restart_file_interval": 0,
+    }
+    if mode != "rerun":
+        settings["vel"] = "vel.dat"
+    if velocities is not None:
+        assert len(velocities) == atom_count
+        velocity_lines = [str(atom_count)]
+        velocity_lines.extend(
+            " ".join(str(component) for component in velocity)
+            for velocity in velocities
+        )
+        (case_dir / "velocity.txt").write_text(
+            "\n".join(velocity_lines) + "\n", encoding="utf-8"
+        )
+        settings["velocity_in_file"] = "velocity.txt"
+    if settings_overrides:
+        settings.update(settings_overrides)
+
+    lines = [f"{key} = {json.dumps(value)}" for key, value in settings.items()]
+    lines.extend(extra_root_lines)
+    if enable_initial_velocity:
+        lines.extend(
+            (
+                "",
+                "[initial_velocity]",
+                'mode = "maxwell"',
+                f"seed = {seed}",
+            )
+        )
+    (case_dir / "mdin.spg.toml").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
+def _run_case(case_dir):
+    sponge_bin = os.environ.get("SPONGE_BIN", "SPONGE")
+    if os.sep in sponge_bin and not os.path.isabs(sponge_bin):
+        sponge_bin = os.path.abspath(sponge_bin)
+    result = subprocess.run(
+        [sponge_bin, "-mdin", "mdin.spg.toml"],
+        cwd=case_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    return result, result.stdout + "\n" + result.stderr
+
+
+def _read_velocity_frame(case_dir, atom_count, name="vel.dat"):
+    raw = (case_dir / name).read_bytes()
+    assert len(raw) == 3 * atom_count * 4
+    values = struct.unpack(f"={3 * atom_count}f", raw)
+    return raw, [
+        values[index : index + 3] for index in range(0, len(values), 3)
+    ]
+
+
+def _assert_succeeded(result, output):
+    assert result.returncode == 0, output
+
+
+def _final_freedom(output):
+    match = re.search(r"INITIAL VELOCITY:.*final freedom (\d+)", output)
+    assert match is not None, output
+    return int(match.group(1))
+
+
+def _temperature(velocities, masses, freedom):
+    kinetic_energy = 0.5 * sum(
+        mass * sum(component * component for component in velocity)
+        for mass, velocity in zip(masses, velocities)
+    )
+    return 2.0 * kinetic_energy / (freedom * KB_KCAL_PER_MOL_K)
+
+
+def _write_constrained_water_case(case_dir, constrain_mode):
+    case_dir.mkdir()
+    masses = (15.999, 1.008, 1.008)
+    coordinates = (
+        (10.0, 10.0, 10.0),
+        (10.9572, 10.0, 10.0),
+        (9.760013, 10.926627, 10.0),
+    )
+    hydrogen_distance = (
+        sum(
+            (coordinates[1][axis] - coordinates[2][axis]) ** 2
+            for axis in range(3)
+        )
+        ** 0.5
+    )
+    (case_dir / "mass.txt").write_text(
+        "3\n" + "\n".join(str(mass) for mass in masses) + "\n",
+        encoding="utf-8",
+    )
+    (case_dir / "charge.txt").write_text("3\n0\n0\n0\n", encoding="utf-8")
+    (case_dir / "coordinate.txt").write_text(
+        "3\n"
+        + "\n".join(
+            " ".join(str(component) for component in coordinate)
+            for coordinate in coordinates
+        )
+        + "\n1000 1000 1000\n90 90 90\n",
+        encoding="utf-8",
+    )
+    (case_dir / "bond.txt").write_text(
+        f"3\n0 1 0 0.9572\n0 2 0 0.9572\n1 2 0 {hydrogen_distance:.12g}\n",
+        encoding="utf-8",
+    )
+    settings = {
+        "md_name": case_dir.name,
+        "mode": "nve",
+        "pbc": False,
+        "step_limit": 1,
+        "dt": 0.001,
+        "cutoff": 8.0,
+        "PM.MPI_size": 0,
+        "target_temperature": 315.0,
+        "mass_in_file": "mass.txt",
+        "charge_in_file": "charge.txt",
+        "coordinate_in_file": "coordinate.txt",
+        "bond_in_file": "bond.txt",
+        "constrain_mode": constrain_mode,
+        "settle_disable": constrain_mode == "SHAKE",
+        "mdout": "mdout.txt",
+        "print_zeroth_frame": True,
+        "write_mdout_interval": 1,
+        "write_information_interval": 1,
+        "write_trajectory_interval": 0,
+        "write_restart_file_interval": 0,
+    }
+    lines = [f"{key} = {json.dumps(value)}" for key, value in settings.items()]
+    lines.extend(("", "[initial_velocity]", 'mode = "maxwell"', "seed = 29"))
+    (case_dir / "mdin.spg.toml").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
+def test_missing_section_preserves_native_velocity_bits(tmp_path):
+    velocities = (
+        (0.125, -0.25, 0.5),
+        (-0.75, 1.0, -1.25),
+        (1.5, -1.75, 2.0),
+        (-2.25, 2.5, -2.75),
+    )
+    case_dir = tmp_path / "native_velocity_passthrough"
+    _write_native_case(
+        case_dir,
+        velocities=velocities,
+        enable_initial_velocity=False,
+    )
+
+    result, output = _run_case(case_dir)
+    _assert_succeeded(result, output)
+    raw, _ = _read_velocity_frame(case_dir, len(velocities))
+    expected = struct.pack(
+        f"={3 * len(velocities)}f",
+        *(component for velocity in velocities for component in velocity),
+    )
+    assert raw == expected
+    assert "INITIAL VELOCITY:" not in output
+
+
+def test_seed_reproducibility_uses_all_64_bits(tmp_path):
+    first = tmp_path / "seed_first"
+    repeated = tmp_path / "seed_repeated"
+    high_bits_differ = tmp_path / "seed_high_bits_differ"
+    _write_native_case(first, seed=1)
+    _write_native_case(repeated, seed=1)
+    _write_native_case(high_bits_differ, seed=1 + (1 << 32))
+
+    outputs = []
+    frames = []
+    for case_dir in (first, repeated, high_bits_differ):
+        result, output = _run_case(case_dir)
+        _assert_succeeded(result, output)
+        outputs.append(output)
+        frames.append(_read_velocity_frame(case_dir, 4)[0])
+
+    assert frames[0] == frames[1]
+    assert frames[0] != frames[2]
+    assert "seed 1," in outputs[0]
+    assert f"seed {1 + (1 << 32)}," in outputs[2]
+
+
+def test_maxwell_velocity_has_zero_com_zero_mass_and_target_energy(tmp_path):
+    masses = (12.0, 16.0, 1.0, 0.0)
+    target = 337.0
+    case_dir = tmp_path / "maxwell_invariants"
+    _write_native_case(
+        case_dir,
+        masses=masses,
+        seed=9223372036854775807,
+        target_temperature=target,
+    )
+
+    result, output = _run_case(case_dir)
+    _assert_succeeded(result, output)
+    _, velocities = _read_velocity_frame(case_dir, len(masses))
+    freedom = _final_freedom(output)
+
+    assert velocities[-1] == (0.0, 0.0, 0.0)
+    momentum = [
+        sum(mass * velocity[axis] for mass, velocity in zip(masses, velocities))
+        for axis in range(3)
+    ]
+    momentum_scale = max(
+        1.0,
+        sum(
+            mass * abs(component)
+            for mass, velocity in zip(masses, velocities)
+            for component in velocity
+        ),
+    )
+    assert (
+        max(abs(component) for component in momentum) <= 2.0e-7 * momentum_scale
+    )
+    assert _temperature(velocities, masses, freedom) == pytest.approx(
+        target, rel=1.0e-5
+    )
+    assert "projected" in output
+    assert f"final {target:g} K" in output
+
+
+def test_step_zero_temperature_schedule_controls_initial_energy(tmp_path):
+    target = 425.0
+    case_dir = tmp_path / "step_zero_schedule"
+    _write_native_case(
+        case_dir,
+        target_temperature=300.0,
+        extra_root_lines=(
+            'target_temperature_schedule_mode = "step"',
+            "target_temperature_schedule_steps = "
+            "[{ step = 0, value = 425.0 }, { step = 1, value = 300.0 }]",
+        ),
+    )
+
+    result, output = _run_case(case_dir)
+    _assert_succeeded(result, output)
+    _, velocities = _read_velocity_frame(case_dir, 4)
+    assert _temperature(
+        velocities, (12.0, 16.0, 1.0, 0.0), _final_freedom(output)
+    ) == pytest.approx(target, rel=1.0e-5)
+    assert "target 425 K" in output
+
+
+@pytest.mark.parametrize("constrain_mode", ["SETTLE", "SHAKE"])
+def test_maxwell_finalize_with_water_constraints(tmp_path, constrain_mode):
+    case_dir = tmp_path / constrain_mode.lower()
+    _write_constrained_water_case(case_dir, constrain_mode)
+
+    result, output = _run_case(case_dir)
+    _assert_succeeded(result, output)
+    expected_backend_log = (
+        "rigid triangle numbers is 1"
+        if constrain_mode == "SETTLE"
+        else "END INITIALIZING SHAKE"
+    )
+    assert expected_backend_log in output
+    assert _final_freedom(output) == 6
+    final_match = re.search(
+        r"INITIAL VELOCITY: projected [^ ]+ K, final ([^ ]+) K", output
+    )
+    assert final_match is not None, output
+    assert float(final_match.group(1)) == pytest.approx(315.0, rel=1.0e-6)
+
+    mdout_lines = (
+        (case_dir / "mdout.txt").read_text(encoding="utf-8").splitlines()
+    )
+    assert len(mdout_lines) >= 2, output
+    assert all(math.isfinite(float(value)) for value in mdout_lines[1].split())
+
+
+@pytest.mark.parametrize("mode", ["minimization", "rerun"])
+def test_maxwell_is_rejected_for_non_dynamical_modes(tmp_path, mode):
+    case_dir = tmp_path / mode
+    settings = {}
+    if mode == "minimization":
+        settings.update(
+            {
+                "minimization_dynamic_dt": 0,
+                "minimization_max_move": 0.1,
+                "dt": 0.001,
+            }
+        )
+    else:
+        settings.update(
+            {
+                "crd": "trajectory.dat",
+                "box": "box.txt",
+                "rerun_need_box_update": 1,
+            }
+        )
+    _write_native_case(
+        case_dir,
+        mode=mode,
+        settings_overrides=settings,
+    )
+    if mode == "rerun":
+        (case_dir / "trajectory.dat").write_bytes(
+            struct.pack("=12f", *([0.0] * 12))
+        )
+        (case_dir / "box.txt").write_text(
+            "1000 1000 1000 90 90 90\n", encoding="utf-8"
+        )
+
+    result, output = _run_case(case_dir)
+    assert result.returncode != 0, output
+    assert (
+        "mode=maxwell is not defined for minimization or rerun mode" in output
+    )
+
+
+def test_maxwell_runs_through_amber_loader(tmp_path):
+    source = (
+        REPO_ROOT
+        / "benchmarks/comparison/reference/amber/statics/alanine_dipeptide_gb1"
+    )
+    case_dir = tmp_path / "amber_loader"
+    case_dir.mkdir()
+    for name in ("system.parm7", "system.rst7"):
+        shutil.copy2(source / name, case_dir / name)
+    lines = [
+        'md_name = "initial velocity amber loader"',
+        'mode = "nve"',
+        "pbc = false",
+        "step_limit = 1",
+        "dt = 0",
+        "cutoff = 999.0",
+        'amber_parm7 = "system.parm7"',
+        'amber_rst7 = "system.rst7"',
+        'vel = "vel.dat"',
+        "write_mdout_interval = 1",
+        "write_information_interval = 1",
+        "write_trajectory_interval = 1",
+        "write_restart_file_interval = 0",
+        "",
+        "[initial_velocity]",
+        'mode = "maxwell"',
+        "seed = 17",
+    ]
+    (case_dir / "mdin.spg.toml").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+    result, output = _run_case(case_dir)
+    _assert_succeeded(result, output)
+    raw, _ = _read_velocity_frame(case_dir, 22)
+    assert any(raw)
+    assert "INITIAL VELOCITY: mode=maxwell, seed 17" in output
+
+
+def _gro_atom(resid, resname, atomname, atomnr, xyz):
+    x, y, z = xyz
+    return (
+        f"{resid:5d}{resname:<5}{atomname:>5}{atomnr:5d}"
+        f"{x:8.3f}{y:8.3f}{z:8.3f}"
+    )
+
+
+def test_maxwell_runs_through_direct_gromacs_loader(tmp_path):
+    case_dir = tmp_path / "gromacs_loader"
+    case_dir.mkdir()
+    (case_dir / "topol.top").write_text(
+        textwrap.dedent(
+            """
+            [ defaults ]
+            1 2 yes 1.0 1.0
+
+            [ atomtypes ]
+            A A 12.0 0.0 A 0.3 0.4184
+            B B 16.0 0.0 A 0.3 0.4184
+
+            [ moleculetype ]
+            PAIR 0
+
+            [ atoms ]
+            1 A 1 PAIR A 1 0.0 12.0
+            2 B 1 PAIR B 2 0.0 16.0
+
+            [ system ]
+            initial velocity direct loader test
+
+            [ molecules ]
+            PAIR 1
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (case_dir / "conf.gro").write_text(
+        "\n".join(
+            (
+                "initial velocity direct loader test",
+                "2",
+                _gro_atom(1, "PAIR", "A", 1, (0.0, 0.0, 0.0)),
+                _gro_atom(1, "PAIR", "B", 2, (0.5, 0.0, 0.0)),
+                " 100.00000 100.00000 100.00000",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (case_dir / "mdin.spg.toml").write_text(
+        textwrap.dedent(
+            """
+            md_name = "initial velocity direct GROMACS loader"
+            mode = "nve"
+            pbc = false
+            step_limit = 1
+            dt = 0
+            cutoff = 8.0
+            gromacs_top = "topol.top"
+            gromacs_gro = "conf.gro"
+            vel = "vel.dat"
+            write_mdout_interval = 1
+            write_information_interval = 1
+            write_trajectory_interval = 1
+            write_restart_file_interval = 0
+
+            [initial_velocity]
+            mode = "maxwell"
+            seed = 23
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result, output = _run_case(case_dir)
+    _assert_succeeded(result, output)
+    _, velocities = _read_velocity_frame(case_dir, 2)
+    freedom = _final_freedom(output)
+    assert _temperature(velocities, (12.0, 16.0), freedom) == pytest.approx(
+        300.0, rel=1.0e-5
+    )
+    assert "INITIAL VELOCITY: mode=maxwell, seed 23" in output

--- a/cmake/targets/SPONGE.cmake
+++ b/cmake/targets/SPONGE.cmake
@@ -4,6 +4,7 @@ set(SPONGE_SOURCES
     ${PROJECT_ROOT_DIR}/SPONGE/control.cpp
     ${PROJECT_ROOT_DIR}/SPONGE/xponge/xponge.cpp
     ${PROJECT_ROOT_DIR}/SPONGE/MD_core/MD_core.cpp
+    ${PROJECT_ROOT_DIR}/SPONGE/MD_core/initial_velocity.cpp
     ${PROJECT_ROOT_DIR}/SPONGE/Domain_decomposition/Domain_decomposition.cpp
     ${PROJECT_ROOT_DIR}/SPONGE/neighbor_list/neighbor_list.cpp
     ${PROJECT_ROOT_DIR}/SPONGE/neighbor_list/full_neighbor_list.cpp

--- a/docs/input-reference/core.md
+++ b/docs/input-reference/core.md
@@ -60,6 +60,24 @@ Temperature and pressure also support schedules through the top-level keys
 `target_temperature_schedule_*` and `target_pressure_schedule_*`. See
 [Thermostat](thermostat.md) and [Barostat](barostat.md).
 
+## Initial Velocities
+
+SPONGE preserves the velocities supplied by the selected input loader unless
+initialization is requested explicitly:
+
+```toml
+[initial_velocity]
+mode = "maxwell"
+seed = 202607220001
+```
+
+`mode = "maxwell"` samples velocities at the step-zero target temperature,
+removes center-of-mass motion, projects constrained systems onto the
+SHAKE/SETTLE velocity manifold without moving their coordinates, and rescales
+using the final system degrees of freedom. `seed` is required and must be an
+integer in `0..INT64_MAX`; it is independent of thermostat seeds. This mode is
+available for dynamical simulations, not minimization or rerun.
+
 ## Working Directory
 
 | Parameter | Type | Default | Description |

--- a/skills/sponge-toml-input/reference/core.md
+++ b/skills/sponge-toml-input/reference/core.md
@@ -46,6 +46,18 @@
 
 温度和压力支持 schedule（分步/线性变化），详见 [thermostat.md](thermostat.md) 和 [barostat.md](barostat.md)。
 
+## 初始速度
+
+默认情况下，SPONGE 保留当前输入格式所提供的速度。需要显式生成热初速时使用：
+
+```toml
+[initial_velocity]
+mode = "maxwell"
+seed = 202607220001
+```
+
+`mode = "maxwell"` 按第 0 步目标温度采样速度，去除质心平动，对约束体系执行不改变坐标的 SHAKE/SETTLE 速度投影，再按最终体系自由度精确定温。`seed` 必填，范围为 `0..INT64_MAX`，且不与恒温器 seed 共用。该模式只用于动力学模拟，不支持 minimization 或 rerun。
+
 ## 工作目录
 
 | 参数 | 类型 | 默认值 | 说明 |


### PR DESCRIPTION
Add constrained Maxwell initial-velocity generation to master from lab/pku (PR #57). This adds the initialization entry point, configuration documentation, and validation coverage.

The branch contains two commits beyond the current master, including its merge commit. This PR should be merged before the separate lab/sidereus-ai integration PR.

Validation: existing branch validation is documented in PR #57; this PR triggers checks against master. No additional local validation was performed when opening this PR.
