### PR TITLE
fix: address release readiness issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 
 当你需要了解或操作 SPONGE 时：
 
-- 如果你是人类用户：请阅读 `docs` 文件夹中的开发与使用文档。
+- 如果你是人类用户：请从[快速入门](docs/getting-started.md)和
+  [输入参数参考](docs/input-reference/README.md)开始。
 - 如果你是 AI 助手：
   - 若用于使用 SPONGE：将本项目的 `skills` 安装到你的全局 skills 目录，例如 `~/.claude/skills` 或 `~/.agents/skills`。
   - 若用于开发 SPONGE：将你的项目级 skills 目录链接到本项目的 `skills`，例如 `.claude/skills` 或 `.agents/skills`。

--- a/README_en.md
+++ b/README_en.md
@@ -20,7 +20,8 @@ Official website: https://spongemm.cn
 
 When you need to understand or work with SPONGE:
 
-- If you are a human user, read the development and usage documents in the `docs` folder.
+- If you are a human user, start with the [Getting Started guide](docs/getting-started.md)
+  and the [Input File Reference](docs/input-reference/README.md).
 - If you are an AI assistant:
   - For using SPONGE, install this project's `skills` into your global skills directory, for example `~/.claude/skills` or `~/.agents/skills`.
   - For developing SPONGE, link your project-level skills directory to this project's `skills`, for example `.claude/skills` or `.agents/skills`.

--- a/SPONGE/NO_PBC/generalized_Born.cpp
+++ b/SPONGE/NO_PBC/generalized_Born.cpp
@@ -285,7 +285,6 @@ void GENERALIZED_BORN_INFORMATION::Initial(CONTROLLER* controller, float cutoff,
     else
     {
         controller->printf("    Error: GB need radii and scaled factor");
-        getchar();
         exit(1);
     }
 

--- a/SPONGE/control.cpp
+++ b/SPONGE/control.cpp
@@ -1,7 +1,6 @@
 ﻿#include "control.h"
 
-#define SPONGE_CODENAME "2026-04-01 April Fools' Day"
-#define SPONGE_VERSION "v" SPONGE_VERSION_STR " " SPONGE_CODENAME
+#define SPONGE_VERSION "v" SPONGE_VERSION_STR
 
 static const char* SPONGE_ASCII_ART = R"( ____  ____   ___  _   _  ____ _____
 / ___||  _ \ / _ \| \ | |/ ___| ____|

--- a/SPONGE/custom_force/listed_forces.h
+++ b/SPONGE/custom_force/listed_forces.h
@@ -1,5 +1,6 @@
 ﻿/*
- * Copyright 2021-2023 Gao's lab, Peking University, CCME. All rights reserved.
+ * Copyright (c) 2022-2026 Beijing Sidereus Intelligent Computing Technology
+ * Co., Ltd. and contributors. All rights reserved.
  *
  * This file is part of SPONGE and is licensed under the SPONGE Licensing
  * Agreement in the repository root. The English text in LICENSE controls.

--- a/SPONGE/virtual_atoms/virtual_atom_math.h
+++ b/SPONGE/virtual_atoms/virtual_atom_math.h
@@ -13,9 +13,9 @@ __device__ __forceinline__ void Virtual_Atom_Add_Source_Force(
 }
 
 __host__ __device__ __forceinline__ VECTOR
-Virtual_Atom_Type_0_Position(VECTOR source, float h_double)
+Virtual_Atom_Type_0_Position(VECTOR source, float h)
 {
-    source.z = 2.0f * h_double - source.z;
+    source.z = 2.0f * h - source.z;
     return source;
 }
 

--- a/SPONGE/virtual_atoms/virtual_atoms.cpp
+++ b/SPONGE/virtual_atoms/virtual_atoms.cpp
@@ -18,8 +18,7 @@ static __global__ void v0_Coordinate_Refresh(const int virtual_numbers,
         VIRTUAL_TYPE_0 v_temp = v_info[i];
         int atom_v = v_temp.virtual_atom;
         int atom_1 = v_temp.from_1;
-        crd[atom_v] =
-            Virtual_Atom_Type_0_Position(crd[atom_1], v_temp.h_double);
+        crd[atom_v] = Virtual_Atom_Type_0_Position(crd[atom_1], v_temp.h);
     }
 }
 
@@ -592,7 +591,7 @@ void VIRTUAL_INFORMATION::Initial(CONTROLLER* controller,
                         temp_vl->v0_info.h_virtual_type_0[count0[this_level]]
                             .from_1 = record.from[0];
                         temp_vl->v0_info.h_virtual_type_0[count0[this_level]]
-                            .h_double = 2 * record.parameter[0];
+                            .h = record.parameter[0];
                         count0[this_level]++;
                         break;
 

--- a/SPONGE/virtual_atoms/virtual_atoms.h
+++ b/SPONGE/virtual_atoms/virtual_atoms.h
@@ -13,16 +13,13 @@
 // own source. Repeated source indices alone are not self-dependencies.
 //
 // Virtual atom type 0: reflection in a plane normal to the z axis.
-//   Intended: x_v = x_1, y_v = y_1, z_v = 2 * h - z_1.
-//   NOTE: the loader stores h_double = 2 * h, but the current position
-//   helper computes z_v = 2 * h_double - z_1 (i.e. 4 * h - z_1).
-//   This legacy factor-of-two discrepancy is not corrected here.
+//   Position: x_v = x_1, y_v = y_1, z_v = 2 * h - z_1.
 //   Force: F_1 += (F_v.x, F_v.y, -F_v.z).
 struct VIRTUAL_TYPE_0
 {
     int virtual_atom;
     int from_1;
-    float h_double;
+    float h;
 };
 
 struct VIRTUAL_TYPE_0_INFROMATION

--- a/benchmarks/bundled_io/tests/test_bundled_io_ab_production.py
+++ b/benchmarks/bundled_io/tests/test_bundled_io_ab_production.py
@@ -19594,11 +19594,10 @@ def _canonicalize_virtual_atom_positions(
         for record in records_by_level[level]:
             source = [coordinates[index] for index in record.source_atoms]
             if record.kind == 0:
-                h_double = 2.0 * record.parameters[0]
                 coordinates[record.atom] = [
                     source[0][0],
                     source[0][1],
-                    2.0 * h_double - source[0][2],
+                    2.0 * record.parameters[0] - source[0][2],
                 ]
             elif record.kind == 1:
                 delta = _lower_triangular_periodic_displacement(

--- a/benchmarks/validation/nopbc/tests/test_virtual_atoms.py
+++ b/benchmarks/validation/nopbc/tests/test_virtual_atoms.py
@@ -142,7 +142,7 @@ def test_type0_virtual_atom_reflects_force_and_clears_target(
     output_coordinates, forces = _run(case_dir, len(coordinates), mpi_np)
 
     np.testing.assert_allclose(
-        output_coordinates[1], (100.0, 100.0, 5.0), atol=2.0e-5
+        output_coordinates[1], (100.0, 100.0, 1.0), atol=2.0e-5
     )
     np.testing.assert_allclose(forces[1], 0.0, atol=1.0e-7)
     virtual_force = -forces[2]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,11 +94,13 @@ dt = 0.002
 cutoff = 8.0
 default_in_file_prefix = "WAT"
 constrain_mode = "SHAKE"
-thermostat = "middle_langevin"
-thermostat_tau = 0.1
-thermostat_seed = 2026
 target_temperature = 300.0
 write_information_interval = 1000
+
+[thermostat]
+mode = "middle_langevin"
+tau = 0.1
+seed = 2026
 ```
 
 Use the command that matches how SPONGE was installed.

--- a/docs/input-reference/README.md
+++ b/docs/input-reference/README.md
@@ -1,6 +1,8 @@
 # Input File Reference
 
-SPONGE input files use TOML format. The default filename is `mdin.spg.toml`, specified via the `-mdin` flag:
+SPONGE automatically reads `mdin.spg.toml` from the working directory. If it
+is absent, the legacy `mdin.txt` input is also recognized. Use `-mdin` to
+select another input file explicitly:
 
 ```bash
 SPONGE -mdin mdin.spg.toml

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -36,9 +36,9 @@ VIProductVersion "${PRODUCT_VERSION}"
 VIAddVersionKey "FileVersion"     "${PRODUCT_VERSION}"
 VIAddVersionKey "ProductName"     "${PRODUCT_NAME}"
 VIAddVersionKey "ProductVersion"  "${DISPLAY_VERSION}"
-VIAddVersionKey "CompanyName"     "SPONGE Development Team"
+VIAddVersionKey "CompanyName"     "Beijing Sidereus Intelligent Computing Technology Co., Ltd."
 VIAddVersionKey "FileDescription" "${PRODUCT_NAME} Installer"
-VIAddVersionKey "LegalCopyright"  "Copyright (c) 2022-2026 SPONGE Development Team"
+VIAddVersionKey "LegalCopyright"  "Copyright (c) 2022-2026 Sidereus-AI and contributors"
 
 ; ---------- Multi-language ----------
 !define MUI_LANGDLL_ALLLANGUAGES
@@ -98,7 +98,7 @@ Section "$(SEC_MAIN_NAME)" SecMain
   WriteRegStr HKLM "${UNINSTALL_KEY}" \
     "UninstallString" '"$INSTDIR\uninstall.exe"'
   WriteRegStr HKLM "${UNINSTALL_KEY}" \
-    "Publisher" "SPONGE Development Team"
+    "Publisher" "Beijing Sidereus Intelligent Computing Technology Co., Ltd."
   WriteRegStr HKLM "${UNINSTALL_KEY}" \
     "DisplayVersion" "${DISPLAY_VERSION}"
   WriteRegDWORD HKLM "${UNINSTALL_KEY}" \

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -11,6 +11,7 @@
 
 ; ---------- Build-time defines (set by installer.ps1) ----------
 ; !define PRODUCT_VERSION "2.0.0.0"
+; !define DISPLAY_VERSION "2.0.0"
 ; !define VARIANT         "CPU"
 ; !define STAGE_DIR       "release-artifacts\nsis\stage"
 ; !define OUTPUT_PATH     "release-artifacts\nsis\SPONGE-CPU-v2.0.0-installer.exe"
@@ -23,7 +24,7 @@
 !define UNINSTALL_KEY   "Software\Microsoft\Windows\CurrentVersion\Uninstall\SPONGE-${VARIANT}"
 
 ; ---------- Installer attributes ----------
-Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
+Name "${PRODUCT_NAME} ${DISPLAY_VERSION}"
 OutFile "${OUTPUT_PATH}"
 InstallDir "$PROGRAMFILES64\${INSTALL_DIR}"
 InstallDirRegKey HKLM "${REG_KEY}" "InstallDir"
@@ -34,7 +35,7 @@ Unicode true
 VIProductVersion "${PRODUCT_VERSION}"
 VIAddVersionKey "FileVersion"     "${PRODUCT_VERSION}"
 VIAddVersionKey "ProductName"     "${PRODUCT_NAME}"
-VIAddVersionKey "ProductVersion"  "${PRODUCT_VERSION}"
+VIAddVersionKey "ProductVersion"  "${DISPLAY_VERSION}"
 VIAddVersionKey "CompanyName"     "SPONGE Development Team"
 VIAddVersionKey "FileDescription" "${PRODUCT_NAME} Installer"
 VIAddVersionKey "LegalCopyright"  "Copyright (c) 2022-2026 SPONGE Development Team"
@@ -99,7 +100,7 @@ Section "$(SEC_MAIN_NAME)" SecMain
   WriteRegStr HKLM "${UNINSTALL_KEY}" \
     "Publisher" "SPONGE Development Team"
   WriteRegStr HKLM "${UNINSTALL_KEY}" \
-    "DisplayVersion" "${PRODUCT_VERSION}"
+    "DisplayVersion" "${DISPLAY_VERSION}"
   WriteRegDWORD HKLM "${UNINSTALL_KEY}" \
     "NoModify" 1
   WriteRegDWORD HKLM "${UNINSTALL_KEY}" \

--- a/packaging/windows/installer.ps1
+++ b/packaging/windows/installer.ps1
@@ -13,11 +13,15 @@ $PSNativeCommandUseErrorActionPreference = $true
 function Get-ProductVersion {
     param([string]$TagName)
 
+    if (-not $TagName) {
+        return "0.0.0.0"
+    }
+
     if ($TagName -match '^v(\d+)\.(\d+)\.(\d+)$') {
         return "$($Matches[1]).$($Matches[2]).$($Matches[3]).0"
     }
 
-    if ($TagName -match '^v(\d+)\.(\d+)\.(\d+)(alpha|beta|rc)(\d+)$') {
+    if ($TagName -match '^v(\d+)\.(\d+)\.(\d+)-(alpha|beta|rc)\.(\d+)$') {
         $major = [int]$Matches[1]
         $minor = [int]$Matches[2]
         $patch = [int]$Matches[3]
@@ -34,7 +38,7 @@ function Get-ProductVersion {
         return "$major.$minor.$patch.$($offset + $number)"
     }
 
-    return "2.0.0.0"
+    throw "Unsupported release tag: $TagName"
 }
 
 $repoRoot = Resolve-Path "."
@@ -77,6 +81,7 @@ foreach ($dllDir in @($exeDir, $runtimeBinDir)) {
 # Resolve paths
 $tagLabel = if ($Tag) { $Tag } else { "dev" }
 $productVersion = Get-ProductVersion $Tag
+$displayVersion = if ($Tag) { $Tag.Substring(1) } else { "dev" }
 $variantUpper = $Variant.ToUpper()
 $outputPath = Join-Path (Resolve-Path $OutputDir) "SPONGE-$variantUpper-$tagLabel-installer.exe"
 $nsiFullPath = Join-Path $repoRoot $NsiPath
@@ -102,6 +107,7 @@ $utf8Bom = New-Object System.Text.UTF8Encoding $true
 # Build installer
 & $makensis `
     /DPRODUCT_VERSION="$productVersion" `
+    /DDISPLAY_VERSION="$displayVersion" `
     /DVARIANT="$variantUpper" `
     /DSTAGE_DIR="$stageFullPath" `
     /DOUTPUT_PATH="$outputPath" `

--- a/plugins/prips/LICENSE
+++ b/plugins/prips/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2026 SPONGE Development Team
+Copyright (c) 2022-2026 Beijing Sidereus Intelligent Computing Technology
+Co., Ltd. and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/virtual_atoms/test_virtual_atom_core.cpp
+++ b/tests/virtual_atoms/test_virtual_atom_core.cpp
@@ -140,7 +140,7 @@ bool Check_Math()
     const Boundary periodic = Boundary{BoundaryPolicy::Periodic, cell, rcell};
     const VECTOR force_v(1.2f, -0.7f, 0.4f);
 
-    ok &= Check_Vector("type 0 compatibility position",
+    ok &= Check_Vector("type 0 reflection position",
                        Virtual_Atom_Type_0_Position({1.0f, 2.0f, 3.0f}, 4.0f),
                        {1.0f, 2.0f, 5.0f});
     ok &= Check_Vector("type 0 source force",


### PR DESCRIPTION
## Summary

- correct virtual atom type 0 reflection to use z_v = 2h - z_source while preserving the existing input format
- parse standard SemVer release tags in the Windows installer and separate numeric file versions from display versions
- remove the blocking stdin read from the missing-GB-parameters error path
- align the getting-started TOML example and documentation entry points with current behavior
- remove the stale hard-coded release codename

## Validation

- full dev-cpu SPONGE build
- SPONGE -v reports only the version sourced from pixi.toml
- all 44 configured CTest tests passed; 4 existing runtime tests were skipped by configuration
- all 10 noPBC virtual atom validation tests passed
- mdin schema example validation passed
- repository format-check passed
- git diff --check passed

Windows PowerShell and NSIS packaging will be validated by the Windows release CI job.